### PR TITLE
implement `POST /api/v0/signature_devices`

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -42,7 +42,7 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 	err := json.NewDecoder(request.Body).Decode(&requestBody)
 	if err != nil {
 		WriteErrorResponse(response, http.StatusBadRequest, []string{
-			http.StatusText(http.StatusBadRequest),
+			"invalid json",
 		})
 		return
 	}

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -55,6 +55,18 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		return
 	}
 
+	_, ok, err := s.signatureDeviceRepository.Find(id)
+	if err != nil {
+		WriteInternalError(response)
+		return
+	}
+	if ok {
+		WriteErrorResponse(response, http.StatusBadRequest, []string{
+			"duplicate id",
+		})
+		return
+	}
+
 	algorithm, found := crypto.FindSupportedAlgorithm(requestBody.Algorithm)
 	if !found {
 		WriteErrorResponse(response, http.StatusBadRequest, []string{

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -13,19 +13,19 @@ type SignatureService struct {
 	signatureDeviceRepository domain.SignatureDeviceRepository
 }
 
-func NewSignatureService(signatureDeviceRepository domain.SignatureDeviceRepository) SignatureService {
+func NewSignatureService(repository domain.SignatureDeviceRepository) SignatureService {
 	return SignatureService{
-		signatureDeviceRepository: signatureDeviceRepository,
+		signatureDeviceRepository: repository,
 	}
 }
 
 // TODO: REST endpoints ...
 type CreateSignatureDeviceResponse struct {
-	Id string `json:"signatureDeviceId"`
+	ID string `json:"signatureDeviceId"`
 }
 
 type CreateSignatureDeviceRequest struct {
-	Id        string `json:"id"`
+	ID        string `json:"id"`
 	Algorithm string `json:"algorithm"`
 	Label     string `json:"label"` // optional
 }
@@ -47,7 +47,7 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		return
 	}
 
-	id, err := uuid.Parse(requestBody.Id)
+	id, err := uuid.Parse(requestBody.ID)
 	if err != nil {
 		WriteErrorResponse(response, http.StatusBadRequest, []string{
 			"id is not a valid uuid",
@@ -90,7 +90,7 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 	}
 
 	responseBody := CreateSignatureDeviceResponse{
-		Id: requestBody.Id,
+		ID: requestBody.ID,
 	}
 	WriteAPIResponse(response, http.StatusCreated, responseBody)
 }

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -54,14 +54,8 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		return
 	}
 
-	var algorithm domain.SignatureAlgorithm
-	for _, alg := range crypto.SupportedAlgorithms {
-		if alg.Name() == requestBody.Algorithm {
-			algorithm = alg
-			break
-		}
-	}
-	if algorithm == nil {
+	algorithm, found := crypto.FindSupportedAlgorithm(requestBody.Algorithm)
+	if !found {
 		WriteErrorResponse(response, http.StatusBadRequest, []string{
 			"algorithm is not supported",
 		})

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -1,3 +1,26 @@
 package api
 
+import (
+	"net/http"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+)
+
+type SignatureService struct {
+	signatureDeviceRepository domain.SignatureDeviceRepository
+}
+
+func NewSignatureService(signatureDeviceRepository domain.SignatureDeviceRepository) SignatureService {
+	return SignatureService{
+		signatureDeviceRepository: signatureDeviceRepository,
+	}
+}
+
 // TODO: REST endpoints ...
+type CreateSignatureDeviceResponse struct {
+	signatureDeviceId string
+}
+
+func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, request *http.Request) {
+	WriteAPIResponse(response, http.StatusOK, "")
+}

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -90,7 +90,7 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 	}
 
 	responseBody := CreateSignatureDeviceResponse{
-		ID: requestBody.ID,
+		ID: device.ID.String(),
 	}
 	WriteAPIResponse(response, http.StatusCreated, responseBody)
 }

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+	"github.com/google/uuid"
 )
 
 type SignatureService struct {
@@ -18,9 +21,61 @@ func NewSignatureService(signatureDeviceRepository domain.SignatureDeviceReposit
 
 // TODO: REST endpoints ...
 type CreateSignatureDeviceResponse struct {
-	signatureDeviceId string
+	Id string `json:"signatureDeviceId"`
+}
+
+type CreateSignatureDeviceRequest struct {
+	Id        string `json:"id"`
+	Algorithm string `json:"algorithm"`
 }
 
 func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, request *http.Request) {
-	WriteAPIResponse(response, http.StatusOK, "")
+	if request.Method != http.MethodPost {
+		WriteErrorResponse(response, http.StatusMethodNotAllowed, []string{
+			http.StatusText(http.StatusMethodNotAllowed),
+		})
+		return
+	}
+
+	var requestBody CreateSignatureDeviceRequest
+	err := json.NewDecoder(request.Body).Decode(&requestBody)
+	if err != nil {
+		// TODO: better response code?
+		WriteErrorResponse(response, http.StatusBadRequest, []string{
+			http.StatusText(http.StatusBadRequest),
+		})
+		return
+	}
+
+	id, err := uuid.Parse(requestBody.Id)
+	// TODO: handle invalid uuid
+
+	var algorithm domain.SignatureAlgorithm
+	for _, alg := range crypto.SupportedAlgorithms {
+		if alg.Name() == requestBody.Algorithm {
+			algorithm = alg
+			break
+		}
+	}
+	// TODO: handle invalid algorithm
+
+	device, err := domain.BuildSignatureDevice(id, algorithm)
+	if err != nil {
+		// In a real application, this error would be logged and sent to an error notification service
+		WriteInternalError(response)
+		return
+	}
+
+	// TODO: what if the id is duplicate?
+	err = s.signatureDeviceRepository.Create(device)
+	if err != nil {
+		// In a real application, this error would be logged and sent to an error notification service
+		WriteInternalError(response)
+		return
+	}
+
+	responseBody := CreateSignatureDeviceResponse{
+		Id: requestBody.Id,
+	}
+	WriteAPIResponse(response, http.StatusCreated, responseBody)
 }

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -27,6 +27,7 @@ type CreateSignatureDeviceResponse struct {
 type CreateSignatureDeviceRequest struct {
 	Id        string `json:"id"`
 	Algorithm string `json:"algorithm"`
+	Label     string `json:"label"` // optional
 }
 
 func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, request *http.Request) {
@@ -62,7 +63,7 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		return
 	}
 
-	device, err := domain.BuildSignatureDevice(id, algorithm)
+	device, err := domain.BuildSignatureDevice(id, algorithm, requestBody.Label)
 	if err != nil {
 		// In a real application, this error would be logged and sent to an error notification service
 		WriteInternalError(response)

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCreateSignatureDeviceResponse(t *testing.T) {
-	t.Run("returns MethodNotAllowed when not POST", func(t *testing.T) {
+	t.Run("fails when method is not POST", func(t *testing.T) {
 		request := httptest.NewRequest(http.MethodGet, "/api/v0/signature_devices", nil)
 		responseRecorder := httptest.NewRecorder()
 
@@ -31,63 +31,6 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		expectedBody := `{"errors":["Method Not Allowed"]}`
 		if body != expectedBody {
 			t.Errorf("expected: %s, got: %s", expectedBody, body)
-		}
-	})
-
-	t.Run("creates a SignatureDevice successfully", func(t *testing.T) {
-		id := uuid.New()
-		algorithm := "RSA"
-		request := httptest.NewRequest(
-			http.MethodPost,
-			"/api/v0/signature_devices",
-			strings.NewReader(fmt.Sprintf(`
-			{
-				"id": "%s",
-				"algorithm": "%s"
-			}`, id, algorithm)),
-		)
-		request.Header.Set("Content-Type", "application/json")
-		responseRecorder := httptest.NewRecorder()
-
-		repository := persistence.NewInMemorySignatureDeviceRepository()
-		service := api.NewSignatureService(repository)
-		service.CreateSignatureDevice(responseRecorder, request)
-
-		// check status code
-		expectedStatusCode := http.StatusCreated
-		if responseRecorder.Code != expectedStatusCode {
-			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
-		}
-
-		// check body
-		body := responseRecorder.Body.String()
-		expectedBody := fmt.Sprintf(`{
-  "data": {
-    "signatureDeviceId": "%s"
-  }
-}`, id)
-		diff := cmp.Diff(body, expectedBody)
-		if diff != "" {
-			t.Errorf("unexpected diff: %s", diff)
-		}
-
-		// check persisted data
-		device, found, err := repository.Find(id)
-		if err != nil {
-			t.Error(err)
-		}
-		if !found {
-			t.Error("expected device with id to be found")
-		}
-		if device.ID != id {
-			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
-		}
-		if device.AlgorithmName != algorithm {
-			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
-		}
-		_, err = crypto.NewRSAMarshaler().Unmarshal(device.EncodedPrivateKey)
-		if err != nil {
-			t.Errorf("decode of generated private key failed: %s", err)
 		}
 	})
 
@@ -154,6 +97,128 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		expectedBody := `{"errors":["algorithm is not supported"]}`
 		if body != expectedBody {
 			t.Errorf("expected: %s, got: %s", expectedBody, body)
+		}
+	})
+
+	t.Run("creates a SignatureDevice successfully", func(t *testing.T) {
+		id := uuid.New()
+		algorithm := "RSA"
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v0/signature_devices",
+			strings.NewReader(fmt.Sprintf(`
+			{
+				"id": "%s",
+				"algorithm": "%s"
+			}`, id, algorithm)),
+		)
+		request.Header.Set("Content-Type", "application/json")
+		responseRecorder := httptest.NewRecorder()
+
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		service := api.NewSignatureService(repository)
+		service.CreateSignatureDevice(responseRecorder, request)
+
+		// check status code
+		expectedStatusCode := http.StatusCreated
+		if responseRecorder.Code != expectedStatusCode {
+			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
+		}
+
+		// check body
+		body := responseRecorder.Body.String()
+		expectedBody := fmt.Sprintf(`{
+  "data": {
+    "signatureDeviceId": "%s"
+  }
+}`, id)
+		diff := cmp.Diff(body, expectedBody)
+		if diff != "" {
+			t.Errorf("unexpected diff: %s", diff)
+		}
+
+		// check persisted data
+		device, found, err := repository.Find(id)
+		if err != nil {
+			t.Error(err)
+		}
+		if !found {
+			t.Error("expected device with id to be found")
+		}
+		if device.ID != id {
+			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
+		}
+		if device.AlgorithmName != algorithm {
+			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
+		}
+		if device.Label != "" {
+			t.Errorf("label not persisted correctly. expected blank string, got: %s", device.Label)
+		}
+		_, err = crypto.NewRSAMarshaler().Unmarshal(device.EncodedPrivateKey)
+		if err != nil {
+			t.Errorf("decode of generated private key failed: %s", err)
+		}
+	})
+
+	t.Run("creates a SignatureDevice with a label successfully", func(t *testing.T) {
+		id := uuid.New()
+		algorithm := "RSA"
+		label := "my RSA key"
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v0/signature_devices",
+			strings.NewReader(fmt.Sprintf(`
+			{
+				"id": "%s",
+				"algorithm": "%s",
+				"label": "%s"
+			}`, id, algorithm, label)),
+		)
+		request.Header.Set("Content-Type", "application/json")
+		responseRecorder := httptest.NewRecorder()
+
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		service := api.NewSignatureService(repository)
+		service.CreateSignatureDevice(responseRecorder, request)
+
+		// check status code
+		expectedStatusCode := http.StatusCreated
+		if responseRecorder.Code != expectedStatusCode {
+			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
+		}
+
+		// check body
+		body := responseRecorder.Body.String()
+		expectedBody := fmt.Sprintf(`{
+  "data": {
+    "signatureDeviceId": "%s"
+  }
+}`, id)
+		diff := cmp.Diff(body, expectedBody)
+		if diff != "" {
+			t.Errorf("unexpected diff: %s", diff)
+		}
+
+		// check persisted data
+		device, found, err := repository.Find(id)
+		if err != nil {
+			t.Error(err)
+		}
+		if !found {
+			t.Error("expected device with id to be found")
+		}
+		if device.ID != id {
+			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
+		}
+		if device.AlgorithmName != algorithm {
+			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
+		}
+		if device.Label != label {
+			t.Errorf("label not persisted correctly. expected: %s, got: %s", label, device.Label)
+		}
+		_, err = crypto.NewRSAMarshaler().Unmarshal(device.EncodedPrivateKey)
+		if err != nil {
+			t.Errorf("decode of generated private key failed: %s", err)
 		}
 	})
 }

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/api"
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/persistence"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -84,7 +85,9 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		if device.AlgorithmName != algorithm {
 			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
 		}
-
-		// TODO: check that encoded key is valid
+		_, err = crypto.NewRSAMarshaler().Unmarshal(device.EncodedPrivateKey)
+		if err != nil {
+			t.Errorf("decode of generated private key failed: %s", err)
+		}
 	})
 }

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -1,0 +1,90 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/api"
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/persistence"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCreateSignatureDeviceResponse(t *testing.T) {
+	t.Run("returns MethodNotAllowed when not POST", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodGet, "/api/v0/signature_devices", nil)
+		responseRecorder := httptest.NewRecorder()
+
+		service := api.NewSignatureService(persistence.NewInMemorySignatureDeviceRepository())
+		service.CreateSignatureDevice(responseRecorder, request)
+
+		expectedStatusCode := http.StatusMethodNotAllowed
+		if responseRecorder.Code != expectedStatusCode {
+			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
+		}
+
+		body := responseRecorder.Body.String()
+		expectedBody := `{"errors":["Method Not Allowed"]}`
+		if body != expectedBody {
+			t.Errorf("expected: %s, got: %s", expectedBody, body)
+		}
+	})
+
+	t.Run("creates a SignatureDevice successfully", func(t *testing.T) {
+		id := uuid.New()
+		algorithm := "RSA"
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v0/signature_devices",
+			strings.NewReader(fmt.Sprintf(`
+			{
+				"id": "%s",
+				"algorithm": "%s"
+			}`, id, algorithm)),
+		)
+		request.Header.Set("Content-Type", "application/json")
+		responseRecorder := httptest.NewRecorder()
+
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		service := api.NewSignatureService(repository)
+		service.CreateSignatureDevice(responseRecorder, request)
+
+		// check status code
+		expectedStatusCode := http.StatusCreated
+		if responseRecorder.Code != expectedStatusCode {
+			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
+		}
+
+		// check body
+		body := responseRecorder.Body.String()
+		expectedBody := fmt.Sprintf(`{
+  "data": {
+    "signatureDeviceId": "%s"
+  }
+}`, id)
+		diff := cmp.Diff(body, expectedBody)
+		if diff != "" {
+			t.Errorf("unexpected diff: %s", diff)
+		}
+
+		// check persisted data
+		device, found, err := repository.Find(id)
+		if err != nil {
+			t.Error(err)
+		}
+		if !found {
+			t.Error("expected device with id to be found")
+		}
+		if device.ID != id {
+			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
+		}
+		if device.AlgorithmName != algorithm {
+			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
+		}
+
+		// TODO: check that encoded key is valid
+	})
+}

--- a/signing-service-challenge-go/api/health_test.go
+++ b/signing-service-challenge-go/api/health_test.go
@@ -12,7 +12,7 @@ func TestHealth(t *testing.T) {
 	request := httptest.NewRequest(http.MethodGet, "/api/v0/health", nil)
 	responseRecorder := httptest.NewRecorder()
 
-	server := api.NewServer("")
+	server := api.NewServer("", api.SignatureService{})
 	server.Health(responseRecorder, request)
 
 	expectedStatusCode := http.StatusOK

--- a/signing-service-challenge-go/api/server.go
+++ b/signing-service-challenge-go/api/server.go
@@ -17,14 +17,18 @@ type ErrorResponse struct {
 
 // Server manages HTTP requests and dispatches them to the appropriate services.
 type Server struct {
-	listenAddress string
+	listenAddress    string
+	signatureService SignatureService
 }
 
 // NewServer is a factory to instantiate a new Server.
-func NewServer(listenAddress string) *Server {
+func NewServer(
+	listenAddress string,
+	signatureService SignatureService,
+) *Server {
 	return &Server{
-		listenAddress: listenAddress,
-		// TODO: add services / further dependencies here ...
+		listenAddress:    listenAddress,
+		signatureService: signatureService,
 	}
 }
 
@@ -35,6 +39,7 @@ func (s *Server) Run() error {
 	mux.Handle("/api/v0/health", http.HandlerFunc(s.Health))
 
 	// TODO: register further HandlerFuncs here ...
+	mux.Handle("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
 
 	return http.ListenAndServe(s.listenAddress, mux)
 }

--- a/signing-service-challenge-go/crypto/supported.go
+++ b/signing-service-challenge-go/crypto/supported.go
@@ -6,3 +6,13 @@ var SupportedAlgorithms = []domain.SignatureAlgorithm{
 	ECCAlgorithm{},
 	RSAAlgorithm{},
 }
+
+func FindSupportedAlgorithm(name string) (domain.SignatureAlgorithm, bool) {
+	for _, algorithm := range SupportedAlgorithms {
+		if algorithm.Name() == name {
+			return algorithm, true
+		}
+	}
+
+	return nil, false
+}

--- a/signing-service-challenge-go/crypto/supported.go
+++ b/signing-service-challenge-go/crypto/supported.go
@@ -1,0 +1,8 @@
+package crypto
+
+import "github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+
+var SupportedAlgorithms = []domain.SignatureAlgorithm{
+	ECCAlgorithm{},
+	RSAAlgorithm{},
+}

--- a/signing-service-challenge-go/crypto/supported_test.go
+++ b/signing-service-challenge-go/crypto/supported_test.go
@@ -1,0 +1,23 @@
+package crypto
+
+import "testing"
+
+func TestFindSupportedAlgorithm(t *testing.T) {
+	t.Run("returns found: false when algorithm does not exist", func(t *testing.T) {
+		_, found := FindSupportedAlgorithm("INVALID")
+		if found {
+			t.Error("expected found: false")
+		}
+	})
+
+	t.Run("returns algorithm when algorithm exists", func(t *testing.T) {
+		algorithm, found := FindSupportedAlgorithm("RSA")
+		if !found {
+			t.Error("expected found: true")
+		}
+
+		if algorithm.Name() != "RSA" {
+			t.Errorf("expected %s, got %s", "RSA", algorithm.Name())
+		}
+	})
+}

--- a/signing-service-challenge-go/crypto/supported_test.go
+++ b/signing-service-challenge-go/crypto/supported_test.go
@@ -11,13 +11,14 @@ func TestFindSupportedAlgorithm(t *testing.T) {
 	})
 
 	t.Run("returns algorithm when algorithm exists", func(t *testing.T) {
-		algorithm, found := FindSupportedAlgorithm("RSA")
+		algorithmName := "RSA"
+		algorithm, found := FindSupportedAlgorithm(algorithmName)
 		if !found {
 			t.Error("expected found: true")
 		}
 
-		if algorithm.Name() != "RSA" {
-			t.Errorf("expected %s, got %s", "RSA", algorithm.Name())
+		if algorithm.Name() != algorithmName {
+			t.Errorf("expected %s, got %s", algorithmName, algorithm.Name())
 		}
 	})
 }

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -47,3 +47,7 @@ func BuildSignatureDevice(id uuid.UUID, algorithm SignatureAlgorithm, label ...s
 
 	return device, nil
 }
+
+type SignatureDeviceRepository interface {
+	Create(device SignatureDevice) error
+}

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -50,4 +50,5 @@ func BuildSignatureDevice(id uuid.UUID, algorithm SignatureAlgorithm, label ...s
 
 type SignatureDeviceRepository interface {
 	Create(device SignatureDevice) error
+	Find(id uuid.UUID) (SignatureDevice, bool, error)
 }

--- a/signing-service-challenge-go/go.mod
+++ b/signing-service-challenge-go/go.mod
@@ -4,4 +4,4 @@ go 1.20
 
 require github.com/google/uuid v1.3.0
 
-require github.com/google/go-cmp v0.6.0 // indirect
+require github.com/google/go-cmp v0.6.0

--- a/signing-service-challenge-go/go.mod
+++ b/signing-service-challenge-go/go.mod
@@ -3,3 +3,5 @@ module github.com/fiskaly/coding-challenges/signing-service-challenge
 go 1.20
 
 require github.com/google/uuid v1.3.0
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/signing-service-challenge-go/go.sum
+++ b/signing-service-challenge-go/go.sum
@@ -1,2 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/signing-service-challenge-go/main.go
+++ b/signing-service-challenge-go/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/api"
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/persistence"
 )
 
 const (
@@ -12,7 +13,10 @@ const (
 )
 
 func main() {
-	server := api.NewServer(ListenAddress)
+	server := api.NewServer(
+		ListenAddress,
+		api.NewSignatureService(persistence.NewInMemorySignatureDeviceRepository()),
+	)
 
 	if err := server.Run(); err != nil {
 		log.Fatal("Could not start server on ", ListenAddress)

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -1,3 +1,29 @@
 package persistence
 
-// TODO: in-memory persistence ...
+import (
+	"errors"
+	"fmt"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+	"github.com/google/uuid"
+)
+
+type InMemorySignatureDeviceRepository struct {
+	devices map[uuid.UUID]domain.SignatureDevice
+}
+
+func (repository InMemorySignatureDeviceRepository) Create(device domain.SignatureDevice) error {
+	_, ok := repository.devices[device.ID]
+	if ok {
+		return errors.New(fmt.Sprintf("duplicate id: %s", device.ID))
+	}
+
+	repository.devices[device.ID] = device
+	return nil
+}
+
+func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {
+	return InMemorySignatureDeviceRepository{
+		devices: map[uuid.UUID]domain.SignatureDevice{},
+	}
+}

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -22,6 +22,15 @@ func (repository InMemorySignatureDeviceRepository) Create(device domain.Signatu
 	return nil
 }
 
+func (repository InMemorySignatureDeviceRepository) Find(id uuid.UUID) (domain.SignatureDevice, bool, error) {
+	device, ok := repository.devices[id]
+	if !ok {
+		return domain.SignatureDevice{}, false, nil
+	}
+
+	return device, true, nil
+}
+
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {
 	return InMemorySignatureDeviceRepository{
 		devices: map[uuid.UUID]domain.SignatureDevice{},

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -1,0 +1,80 @@
+package persistence
+
+import (
+	"testing"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCreate(t *testing.T) {
+	t.Run("persists the device in memory", func(t *testing.T) {
+		device := domain.SignatureDevice{
+			ID:                uuid.New(),
+			AlgorithmName:     "RSA",
+			EncodedPrivateKey: []byte("SOME_RSA_KEY"),
+			Label:             "my rsa key",
+		}
+
+		repository := NewInMemorySignatureDeviceRepository()
+
+		if len(repository.devices) != 0 {
+			t.Errorf("new repository should have 0 devices")
+		}
+
+		err := repository.Create(device)
+		if err != nil {
+			t.Errorf("expected no error, got: %s", err)
+		}
+		if len(repository.devices) != 1 {
+			t.Errorf("expected repository to contain 1 device, got: %d", len(repository.devices))
+		}
+
+		persistedDevice, ok := repository.devices[device.ID]
+		if !ok {
+			t.Error("expected device with id to be persisted")
+		}
+		diff := cmp.Diff(persistedDevice, device)
+		if diff != "" {
+			t.Errorf("unexpected difference between original and persisted device: %s", diff)
+		}
+	})
+
+	t.Run("does not persist when id is not unique", func(t *testing.T) {
+		id := uuid.New()
+		alreadyExistingDevice := domain.SignatureDevice{
+			ID:            id,
+			AlgorithmName: "RSA",
+			Label:         "already existing rsa key",
+		}
+		duplicateIdDevice := domain.SignatureDevice{
+			ID:            id,
+			AlgorithmName: "RSA",
+			Label:         "new rsa key",
+		}
+
+		repository := NewInMemorySignatureDeviceRepository()
+		repository.devices[id] = alreadyExistingDevice
+		if len(repository.devices) != 1 {
+			t.Errorf("repository should contain 1 device")
+		}
+
+		err := repository.Create(duplicateIdDevice)
+		if err == nil {
+			t.Error("expected error")
+		}
+		if len(repository.devices) != 1 {
+			t.Errorf("expected repository to contain 1 device, got: %d", len(repository.devices))
+		}
+
+		persistedDevice, ok := repository.devices[id]
+		if !ok {
+			t.Error("expected device with id to be present")
+		}
+		diff := cmp.Diff(persistedDevice, alreadyExistingDevice)
+		if diff != "" {
+			t.Errorf("expected persisted device to not have changed. diff: %s", diff)
+		}
+	})
+}

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -78,3 +78,42 @@ func TestCreate(t *testing.T) {
 		}
 	})
 }
+
+func TestFind(t *testing.T) {
+	t.Run("returns the device when device with id exists", func(t *testing.T) {
+		device := domain.SignatureDevice{
+			ID:                uuid.New(),
+			AlgorithmName:     "RSA",
+			EncodedPrivateKey: []byte("SOME_RSA_KEY"),
+			Label:             "my rsa key",
+		}
+
+		repository := NewInMemorySignatureDeviceRepository()
+		repository.devices[device.ID] = device
+
+		foundDevice, found, err := repository.Find(device.ID)
+		if err != nil {
+			t.Errorf("expected no error, got: %s", err)
+		}
+		if !found {
+			t.Error("expected device to be found")
+		}
+		diff := cmp.Diff(foundDevice, device)
+		if diff != "" {
+			t.Errorf("unexpected difference between original and found device: %s", diff)
+		}
+	})
+
+	t.Run("returns false when device with id does not exist", func(t *testing.T) {
+		id := uuid.New()
+		repository := NewInMemorySignatureDeviceRepository()
+
+		_, found, err := repository.Find(id)
+		if err != nil {
+			t.Errorf("expected no error, got: %s", err)
+		}
+		if found {
+			t.Error("expected found: false")
+		}
+	})
+}


### PR DESCRIPTION
## Objective

Implement the API endpoint with the following functionality

https://github.com/fiskaly/coding-challenges/blob/2a887d6239c595cf2d575d9ea0f15adda73cd2c0/signing-service-challenge-go/README.md?plain=1#L64

## Changes made

### `domain` package
- added `SignatureDeviceRepository` interface 
  - methods: `Create`, `Find`

### `persistence` package
- added `InMemorySignatureDeviceRepository` implementation, which satisfies the `domain.SignatureDeviceRepository` interface

### `api` package

- implemented `SignatureService` struct which implements the `POST /api/v0/signature_devices` logic
- added `SignatureService` as a field to `Server` struct

### `crypto` package
- added `SupportedAlgorithms` variable which lists all supported algorithms
- added `FindSupportedAlgorithm` function

### other
- added the `go-cmp` package to use in tests


## QA

`POST /api/v0/signature_devices` 

- [x] fails when id is not a valid uuid

```
curl -iXPOST localhost:8080/api/v0/signature_devices -d '{"id": "123", "algorithm": "RSA"}'
HTTP/1.1 400 Bad Request
Date: Thu, 25 Jan 2024 17:53:48 GMT
Content-Length: 37
Content-Type: text/plain; charset=utf-8

{"errors":["id is not a valid uuid"]}
```

- [x] fails when id is duplicate

```
$ curl -iXPOST localhost:8080/api
/v0/signature_devices -d '{"id": "0e18ec2b-54cd-4181-8bdd-9016ca526e68", "algorithm": "RSA"}'
HTTP/1.1 400 Bad Request
Date: Fri, 26 Jan 2024 12:09:39 GMT
Content-Length: 27
Content-Type: text/plain; charset=utf-8

{"errors":["duplicate id"]}
```

- [x] fails when algorithm is invalid

```
$ curl -iXPOST localhost:8080/api/v0/signature_devices -d
 '{"id": "0e18ec2b-54cd-4181-8bdd-9016ca526e68", "algorithm": "ABC"}'
HTTP/1.1 400 Bad Request
Date: Fri, 26 Jan 2024 12:01:00 GMT
Content-Length: 41
Content-Type: text/plain; charset=utf-8

{"errors":["algorithm is not supported"]}
```

- [x] succeeds for RSA

```
$ curl -iXPOST localhost:8080/api
/v0/signature_devices -d '{"id": "f8fdace7-5266-477f-9196-57fae84d6301", "algorithm": "RSA"}'
HTTP/1.1 201 Created
Date: Fri, 26 Jan 2024 12:10:08 GMT
Content-Length: 83
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "signatureDeviceId": "f8fdace7-5266-477f-9196-57fae84d6301"
  }
}
```

- [x] succeeds for ECC

```
$ curl -iXPOST localhost:8080/api
/v0/signature_devices -d '{"id": "1b6bfcac-441e-4498-b1e8-5df44dd3d086", "algorithm": "ECC"}'
HTTP/1.1 201 Created
Date: Fri, 26 Jan 2024 12:10:55 GMT
Content-Length: 83
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "signatureDeviceId": "1b6bfcac-441e-4498-b1e8-5df44dd3d086"
  }
}
```

- [x] saves a label when label is provided
- [x] sets a blank string for label when label is not provided
- [x] returns bad request when json is invalid

## Other
- Validation for the length of label should be added in the future, so as to not use up too much memory if a user tries to send a long label