### PR TITLE
refactor SignatureDevice struct to hold SignatureAlgorithm in field

### DIFF
--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -38,13 +38,13 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 
 	t.Run("fails when uuid is invalid", func(t *testing.T) {
 		id := "invalid-uuid"
-		algorithm := "RSA"
+		algorithmName := "RSA"
 		request := newJsonRequest(
 			http.MethodPost,
 			"/api/v0/signature_devices",
 			api.CreateSignatureDeviceRequest{
 				ID:        id,
-				Algorithm: algorithm,
+				Algorithm: algorithmName,
 			},
 		)
 		responseRecorder := httptest.NewRecorder()
@@ -69,13 +69,13 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 
 	t.Run("fails when id already exists", func(t *testing.T) {
 		id := uuid.New()
-		algorithm := "RSA"
+		algorithm := crypto.RSAAlgorithm{}
 		request := newJsonRequest(
 			http.MethodPost,
 			"/api/v0/signature_devices",
 			api.CreateSignatureDeviceRequest{
 				ID:        id.String(),
-				Algorithm: algorithm,
+				Algorithm: algorithm.Name(),
 			},
 		)
 		responseRecorder := httptest.NewRecorder()
@@ -84,7 +84,7 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		// create existing device with the same id
 		repository.Create(domain.SignatureDevice{
 			ID:                id,
-			AlgorithmName:     algorithm,
+			Algorithm:         algorithm,
 			EncodedPrivateKey: []byte("SOME_KEY"),
 		})
 		service := api.NewSignatureService(repository)
@@ -106,13 +106,13 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 
 	t.Run("fails when algorithm is invalid", func(t *testing.T) {
 		id := uuid.New()
-		algorithm := "ABC"
+		algorithmName := "ABC"
 		request := newJsonRequest(
 			http.MethodPost,
 			"/api/v0/signature_devices",
 			api.CreateSignatureDeviceRequest{
 				ID:        id.String(),
-				Algorithm: algorithm,
+				Algorithm: algorithmName,
 			},
 		)
 		responseRecorder := httptest.NewRecorder()
@@ -137,13 +137,13 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 
 	t.Run("creates a SignatureDevice successfully", func(t *testing.T) {
 		id := uuid.New()
-		algorithm := "RSA"
+		algorithmName := "RSA"
 		request := newJsonRequest(
 			http.MethodPost,
 			"/api/v0/signature_devices",
 			api.CreateSignatureDeviceRequest{
 				ID:        id.String(),
-				Algorithm: algorithm,
+				Algorithm: algorithmName,
 			},
 		)
 		responseRecorder := httptest.NewRecorder()
@@ -181,8 +181,8 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		if device.ID != id {
 			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
 		}
-		if device.AlgorithmName != algorithm {
-			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
+		if device.Algorithm.Name() != algorithmName {
+			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithmName, device.Algorithm.Name())
 		}
 		if device.Label != "" {
 			t.Errorf("label not persisted correctly. expected blank string, got: %s", device.Label)
@@ -195,14 +195,14 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 
 	t.Run("creates a SignatureDevice with a label successfully", func(t *testing.T) {
 		id := uuid.New()
-		algorithm := "RSA"
+		algorithmName := "RSA"
 		label := "my RSA key"
 		request := newJsonRequest(
 			http.MethodPost,
 			"/api/v0/signature_devices",
 			api.CreateSignatureDeviceRequest{
 				ID:        id.String(),
-				Algorithm: algorithm,
+				Algorithm: algorithmName,
 				Label:     label,
 			},
 		)
@@ -241,8 +241,8 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		if device.ID != id {
 			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
 		}
-		if device.AlgorithmName != algorithm {
-			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithm, device.AlgorithmName)
+		if device.Algorithm.Name() != algorithmName {
+			t.Errorf("algorithm not persisted correctly. expected: %s, got: %s", algorithmName, device.Algorithm.Name())
 		}
 		if device.Label != label {
 			t.Errorf("label not persisted correctly. expected: %s, got: %s", label, device.Label)

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -18,7 +18,7 @@ type SignatureAlgorithm interface {
 
 type SignatureDevice struct {
 	ID                uuid.UUID
-	AlgorithmName     string
+	Algorithm         SignatureAlgorithm
 	EncodedPrivateKey []byte
 	// (optional) user provided string to be displayed in the UI
 	Label string
@@ -37,7 +37,7 @@ func BuildSignatureDevice(id uuid.UUID, algorithm SignatureAlgorithm, label ...s
 
 	device := SignatureDevice{
 		ID:                id,
-		AlgorithmName:     algorithm.Name(),
+		Algorithm:         algorithm,
 		EncodedPrivateKey: encodedPrivateKey,
 	}
 

--- a/signing-service-challenge-go/domain/device_test.go
+++ b/signing-service-challenge-go/domain/device_test.go
@@ -32,8 +32,8 @@ func TestBuildSignatureDevice(t *testing.T) {
 			t.Errorf("expected id: %s, got: %s", id, device.ID.String())
 		}
 
-		if device.AlgorithmName != algorithm.Name() {
-			t.Errorf("expected algorithm: %s, got: %s", algorithm.Name(), device.AlgorithmName)
+		if device.Algorithm.Name() != algorithm.Name() {
+			t.Errorf("expected algorithm: %s, got: %s", algorithm.Name(), device.Algorithm.Name())
 		}
 
 		if device.SignatureCounter != 0 {

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"testing"
 
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -12,7 +13,7 @@ func TestCreate(t *testing.T) {
 	t.Run("persists the device in memory", func(t *testing.T) {
 		device := domain.SignatureDevice{
 			ID:                uuid.New(),
-			AlgorithmName:     "RSA",
+			Algorithm:         crypto.RSAAlgorithm{},
 			EncodedPrivateKey: []byte("SOME_RSA_KEY"),
 			Label:             "my rsa key",
 		}
@@ -44,14 +45,14 @@ func TestCreate(t *testing.T) {
 	t.Run("does not persist when id is not unique", func(t *testing.T) {
 		id := uuid.New()
 		alreadyExistingDevice := domain.SignatureDevice{
-			ID:            id,
-			AlgorithmName: "RSA",
-			Label:         "already existing rsa key",
+			ID:        id,
+			Algorithm: crypto.RSAAlgorithm{},
+			Label:     "already existing rsa key",
 		}
 		duplicateIdDevice := domain.SignatureDevice{
-			ID:            id,
-			AlgorithmName: "RSA",
-			Label:         "new rsa key",
+			ID:        id,
+			Algorithm: crypto.RSAAlgorithm{},
+			Label:     "new rsa key",
 		}
 
 		repository := NewInMemorySignatureDeviceRepository()
@@ -83,7 +84,7 @@ func TestFind(t *testing.T) {
 	t.Run("returns the device when device with id exists", func(t *testing.T) {
 		device := domain.SignatureDevice{
 			ID:                uuid.New(),
-			AlgorithmName:     "RSA",
+			Algorithm:         crypto.RSAAlgorithm{},
 			EncodedPrivateKey: []byte("SOME_RSA_KEY"),
 			Label:             "my rsa key",
 		}


### PR DESCRIPTION
# Objective

Refactor `SignatureDevice` struct to hold `SignatureAlgorithm` in field.
If `SignatureDevice` only has the `AlgorithmName` as a field, every time a function from `SignatureAlgorithm` needs to be invoked, the corresponding `SignatureAlgorithm` struct needs to be looked up. 
This causes unnecessarily long code and error handling.

## Changes made
- replaced the `SignatureDevice.AlgorithmName` field with `Algorithm` and fixed all usages

## QA
- [x] `POST localhost:8080/api/v0/signature_devices` succeeds