### PR TITLE
use `go-chi` for routing instead of standard go http

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -31,13 +31,6 @@ type CreateSignatureDeviceRequest struct {
 }
 
 func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, request *http.Request) {
-	if request.Method != http.MethodPost {
-		WriteErrorResponse(response, http.StatusMethodNotAllowed, []string{
-			http.StatusText(http.StatusMethodNotAllowed),
-		})
-		return
-	}
-
 	var requestBody CreateSignatureDeviceRequest
 	err := json.NewDecoder(request.Body).Decode(&requestBody)
 	if err != nil {

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -17,25 +17,6 @@ import (
 )
 
 func TestCreateSignatureDeviceResponse(t *testing.T) {
-	t.Run("fails when method is not POST", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodGet, "/api/v0/signature_devices", nil)
-		responseRecorder := httptest.NewRecorder()
-
-		service := api.NewSignatureService(persistence.NewInMemorySignatureDeviceRepository())
-		service.CreateSignatureDevice(responseRecorder, request)
-
-		expectedStatusCode := http.StatusMethodNotAllowed
-		if responseRecorder.Code != expectedStatusCode {
-			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
-		}
-
-		body := responseRecorder.Body.String()
-		expectedBody := `{"errors":["Method Not Allowed"]}`
-		if body != expectedBody {
-			t.Errorf("expected: %s, got: %s", expectedBody, body)
-		}
-	})
-
 	t.Run("fails when uuid is invalid", func(t *testing.T) {
 		id := "invalid-uuid"
 		algorithmName := "RSA"

--- a/signing-service-challenge-go/api/health.go
+++ b/signing-service-challenge-go/api/health.go
@@ -9,13 +9,6 @@ type HealthResponse struct {
 
 // Health evaluates the health of the service and writes a standardized response.
 func (s *Server) Health(response http.ResponseWriter, request *http.Request) {
-	if request.Method != http.MethodGet {
-		WriteErrorResponse(response, http.StatusMethodNotAllowed, []string{
-			http.StatusText(http.StatusMethodNotAllowed),
-		})
-		return
-	}
-
 	health := HealthResponse{
 		Status:  "pass",
 		Version: "v0",

--- a/signing-service-challenge-go/api/server.go
+++ b/signing-service-challenge-go/api/server.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/go-chi/chi/v5"
 )
 
 // Response is the generic API response container.
@@ -34,12 +36,10 @@ func NewServer(
 
 // Run registers all HandlerFuncs for the existing HTTP routes and starts the Server.
 func (s *Server) Run() error {
-	mux := http.NewServeMux()
+	mux := chi.NewMux()
 
-	mux.Handle("/api/v0/health", http.HandlerFunc(s.Health))
-
-	// TODO: register further HandlerFuncs here ...
-	mux.Handle("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
+	mux.Post("/api/v0/health", http.HandlerFunc(s.Health))
+	mux.Post("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
 
 	return http.ListenAndServe(s.listenAddress, mux)
 }

--- a/signing-service-challenge-go/api/server.go
+++ b/signing-service-challenge-go/api/server.go
@@ -38,7 +38,7 @@ func NewServer(
 func (s *Server) Run() error {
 	mux := chi.NewMux()
 
-	mux.Post("/api/v0/health", http.HandlerFunc(s.Health))
+	mux.Get("/api/v0/health", http.HandlerFunc(s.Health))
 	mux.Post("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
 
 	return http.ListenAndServe(s.listenAddress, mux)

--- a/signing-service-challenge-go/go.mod
+++ b/signing-service-challenge-go/go.mod
@@ -5,3 +5,5 @@ go 1.20
 require github.com/google/uuid v1.3.0
 
 require github.com/google/go-cmp v0.6.0
+
+require github.com/go-chi/chi/v5 v5.0.11 // indirect

--- a/signing-service-challenge-go/go.mod
+++ b/signing-service-challenge-go/go.mod
@@ -6,4 +6,4 @@ require github.com/google/uuid v1.3.0
 
 require github.com/google/go-cmp v0.6.0
 
-require github.com/go-chi/chi/v5 v5.0.11 // indirect
+require github.com/go-chi/chi/v5 v5.0.11

--- a/signing-service-challenge-go/go.sum
+++ b/signing-service-challenge-go/go.sum
@@ -1,3 +1,5 @@
+github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
+github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=


### PR DESCRIPTION
## Objective

Fetching URL query parameters easily is not supported in the go 1.20 (although it will be supported in [go 1.22](https://tip.golang.org/doc/go1.22#enhanced_routing_patterns) which will be released in February)

In order to make it easier to implement the endpoint for signing transactions (`POST /api/v0/signature_devices/:id/signatures`), this functionality is necessary, so add https://github.com/go-chi/chi and use it instead of the standard go http package.

## Changes made

- added `go-chi/chi`
- replace `http.ServeMux` with `chi.Mux`
- delete logic guarding against unintended http methods
  - since `chi.Mux` defines routes with a single http method, the above logic is provided by `chi` and is obsolete

## QA
- [x] `GET` requests to `/api/v0/health` succeed
- [x] other http method requests to `/api/v0/health` fail
- [x] `POST` requests to `/api/v0/signature_devices` succeed
- [x] other http method requests to `/api/v0/signature_devices ` fail
