### PR TITLE
implement `POST /api/v0/signature_devices/:deviceID/signatures`

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
 
@@ -86,4 +88,65 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		ID: device.ID.String(),
 	}
 	WriteAPIResponse(response, http.StatusCreated, responseBody)
+}
+
+type SignTransactionRequest struct {
+	Data string `json:"data"`
+}
+
+type SignTransactionResponse struct {
+	Signature  string `json:"signature"`
+	SignedData string `json:"signed_data"`
+}
+
+func (s *SignatureService) SignTransaction(response http.ResponseWriter, request *http.Request) {
+	deviceID := chi.URLParam(request, "deviceID")
+
+	fmt.Printf("deviceID: %s\n", deviceID)
+
+
+	// var requestBody SignTransactionRequest
+	// err := json.NewDecoder(request.Body).Decode(&requestBody)
+	// if err != nil {
+	// 	WriteErrorResponse(response, http.StatusBadRequest, []string{
+	// 		"invalid json",
+	// 	})
+	// 	return
+	// }
+
+	// id, err := uuid.Parse(requestBody.DeviceId)
+	// if err != nil {
+	// 	WriteErrorResponse(response, http.StatusBadRequest, []string{
+	// 		"id is not a valid uuid",
+	// 	})
+	// 	return
+	// }
+
+	// device, ok, err := s.signatureDeviceRepository.Find(id)
+	// if err != nil {
+	// 	WriteInternalError(response)
+	// 	return
+	// }
+	// if !ok {
+	// 	WriteErrorResponse(response, http.StatusNotFound, []string{
+	// 		"signature device not found",
+	// 	})
+	// 	return
+	// }
+
+	// signature, signedData, err := domain.SignTransaction(
+	// 	device,
+	// 	s.signatureDeviceRepository,
+	// 	requestBody.Data,
+	// )
+	// if err != nil {
+	// 	// TODO: better error handling?
+	// 	WriteInternalError(response)
+	// }
+
+	// responseBody := SignTransactionResponse{
+	// 	Signature:  signature,
+	// 	SignedData: signedData,
+	// }
+	WriteAPIResponse(response, http.StatusOK, deviceID)
 }

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
@@ -100,53 +99,52 @@ type SignTransactionResponse struct {
 }
 
 func (s *SignatureService) SignTransaction(response http.ResponseWriter, request *http.Request) {
-	deviceID := chi.URLParam(request, "deviceID")
+	deviceIDString := chi.URLParam(request, "deviceID")
+	deviceID, err := uuid.Parse(deviceIDString)
+	if err != nil {
+		WriteErrorResponse(response, http.StatusBadRequest, []string{
+			"id is not a valid uuid",
+		})
+		return
+	}
 
-	fmt.Printf("deviceID: %s\n", deviceID)
+	device, ok, err := s.signatureDeviceRepository.Find(deviceID)
+	if err != nil {
+		WriteInternalError(response)
+		return
+	}
+	if !ok {
+		WriteErrorResponse(response, http.StatusNotFound, []string{
+			"signature device not found",
+		})
+		return
+	}
 
+	var requestBody SignTransactionRequest
+	err = json.NewDecoder(request.Body).Decode(&requestBody)
+	if err != nil {
+		WriteErrorResponse(response, http.StatusBadRequest, []string{
+			"invalid json",
+		})
+		return
+	}
 
-	// var requestBody SignTransactionRequest
-	// err := json.NewDecoder(request.Body).Decode(&requestBody)
-	// if err != nil {
-	// 	WriteErrorResponse(response, http.StatusBadRequest, []string{
-	// 		"invalid json",
-	// 	})
-	// 	return
-	// }
+	encodedSignature, signedData, err := domain.SignTransaction(
+		device,
+		s.signatureDeviceRepository,
+		requestBody.Data,
+	)
+	if err != nil {
+		// TODO: better error handling?
+		WriteInternalError(response)
+	}
 
-	// id, err := uuid.Parse(requestBody.DeviceId)
-	// if err != nil {
-	// 	WriteErrorResponse(response, http.StatusBadRequest, []string{
-	// 		"id is not a valid uuid",
-	// 	})
-	// 	return
-	// }
-
-	// device, ok, err := s.signatureDeviceRepository.Find(id)
-	// if err != nil {
-	// 	WriteInternalError(response)
-	// 	return
-	// }
-	// if !ok {
-	// 	WriteErrorResponse(response, http.StatusNotFound, []string{
-	// 		"signature device not found",
-	// 	})
-	// 	return
-	// }
-
-	// signature, signedData, err := domain.SignTransaction(
-	// 	device,
-	// 	s.signatureDeviceRepository,
-	// 	requestBody.Data,
-	// )
-	// if err != nil {
-	// 	// TODO: better error handling?
-	// 	WriteInternalError(response)
-	// }
-
-	// responseBody := SignTransactionResponse{
-	// 	Signature:  signature,
-	// 	SignedData: signedData,
-	// }
-	WriteAPIResponse(response, http.StatusOK, deviceID)
+	WriteAPIResponse(
+		response,
+		http.StatusOK,
+		SignTransactionResponse{
+			Signature:  encodedSignature,
+			SignedData: signedData,
+		},
+	)
 }

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -20,7 +20,6 @@ func NewSignatureService(repository domain.SignatureDeviceRepository) SignatureS
 	}
 }
 
-// TODO: REST endpoints ...
 type CreateSignatureDeviceResponse struct {
 	ID string `json:"signatureDeviceId"`
 }
@@ -135,8 +134,8 @@ func (s *SignatureService) SignTransaction(response http.ResponseWriter, request
 		requestBody.Data,
 	)
 	if err != nil {
-		// TODO: better error handling?
 		WriteInternalError(response)
+		return
 	}
 
 	WriteAPIResponse(

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -278,7 +278,7 @@ func TestSignTransaction(t *testing.T) {
 
 	t.Run("successfully signs data with device (algorithm: RSA, counter = 0)", func(t *testing.T) {
 		id := "64ff796e-fcde-499a-a03d-82dd1f89e8e5"
-		base64EncodedId := "NjRmZjc5NmUtZmNkZS00OTlhLWEwM2QtODJkZDFmODllOGU1"
+		base64EncodedID := "NjRmZjc5NmUtZmNkZS00OTlhLWEwM2QtODJkZDFmODllOGU1"
 		dataToSign := "some-data"
 		device, err := domain.BuildSignatureDevice(uuid.MustParse(id), crypto.RSAGenerator{})
 		if err != nil {
@@ -334,7 +334,7 @@ func TestSignTransaction(t *testing.T) {
 		}
 
 		// check signed_data is correct format
-		expectedSignedData := fmt.Sprintf("0_%s_%s", dataToSign, base64EncodedId)
+		expectedSignedData := fmt.Sprintf("0_%s_%s", dataToSign, base64EncodedID)
 		if jsonBody.Data.SignedData != expectedSignedData {
 			t.Errorf("expected signed data: %s, got: %s", expectedSignedData, jsonBody.Data.SignedData)
 		}
@@ -438,7 +438,7 @@ func TestSignTransaction(t *testing.T) {
 
 	t.Run("successfully signs data with device (algorithm: ECC, counter = 0)", func(t *testing.T) {
 		id := "64ff796e-fcde-499a-a03d-82dd1f89e8e5"
-		base64EncodedId := "NjRmZjc5NmUtZmNkZS00OTlhLWEwM2QtODJkZDFmODllOGU1"
+		base64EncodedID := "NjRmZjc5NmUtZmNkZS00OTlhLWEwM2QtODJkZDFmODllOGU1"
 		dataToSign := "some-data"
 		device, err := domain.BuildSignatureDevice(uuid.MustParse(id), crypto.ECCGenerator{})
 		if err != nil {
@@ -494,7 +494,7 @@ func TestSignTransaction(t *testing.T) {
 		}
 
 		// check signed_data is correct format
-		expectedSignedData := fmt.Sprintf("0_%s_%s", dataToSign, base64EncodedId)
+		expectedSignedData := fmt.Sprintf("0_%s_%s", dataToSign, base64EncodedID)
 		if jsonBody.Data.SignedData != expectedSignedData {
 			t.Errorf("expected signed data: %s, got: %s", expectedSignedData, jsonBody.Data.SignedData)
 		}

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
@@ -275,7 +276,7 @@ func TestSignTransaction(t *testing.T) {
 		}
 	})
 
-	t.Run("successfully signs data with device(counter = 0)", func(t *testing.T) {
+	t.Run("successfully signs data with device (algorithm: RSA, counter = 0)", func(t *testing.T) {
 		id := "64ff796e-fcde-499a-a03d-82dd1f89e8e5"
 		base64EncodedId := "NjRmZjc5NmUtZmNkZS00OTlhLWEwM2QtODJkZDFmODllOGU1"
 		dataToSign := "some-data"
@@ -354,7 +355,7 @@ func TestSignTransaction(t *testing.T) {
 		}
 	})
 
-	t.Run("successfully signs data with device(counter > 0)", func(t *testing.T) {
+	t.Run("successfully signs data (algorithm: RSA, counter > 0)", func(t *testing.T) {
 		id := "64ff796e-fcde-499a-a03d-82dd1f89e8e5"
 		dataToSign := "some-data"
 
@@ -410,6 +411,166 @@ func TestSignTransaction(t *testing.T) {
 		}
 		err = rsa.VerifyPSS(keyPair.Public, crypto.HashFunction, digest, decodedSignature, nil)
 		if err != nil {
+			t.Errorf("verification of signed data and signature failed. err: %s, signed data: %s, signature: %s", err, jsonBody.Data.SignedData, jsonBody.Data.Signature)
+		}
+
+		// check signed_data is correct format
+		expectedSignedData := fmt.Sprintf("1_%s_%s", dataToSign, device.Base64EncodedLastSignature)
+		if jsonBody.Data.SignedData != expectedSignedData {
+			t.Errorf("expected signed data: %s, got: %s", expectedSignedData, jsonBody.Data.SignedData)
+		}
+
+		// check persisted data
+		device, ok, err := repository.Find(uuid.MustParse(id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("device not found")
+		}
+		if device.SignatureCounter != 2 {
+			t.Errorf("device signature counter should be incremented to 2, got: %d", device.SignatureCounter)
+		}
+		if device.Base64EncodedLastSignature != jsonBody.Data.Signature {
+			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.Base64EncodedLastSignature)
+		}
+	})
+
+	t.Run("successfully signs data with device (algorithm: ECC, counter = 0)", func(t *testing.T) {
+		id := "64ff796e-fcde-499a-a03d-82dd1f89e8e5"
+		base64EncodedId := "NjRmZjc5NmUtZmNkZS00OTlhLWEwM2QtODJkZDFmODllOGU1"
+		dataToSign := "some-data"
+		device, err := domain.BuildSignatureDevice(uuid.MustParse(id), crypto.ECCGenerator{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		err = repository.Create(device)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signatureService := api.NewSignatureService(repository)
+		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
+		defer testServer.Close()
+
+		response := sendJsonRequest(
+			t,
+			http.MethodPost,
+			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
+			api.SignTransactionRequest{Data: dataToSign},
+		)
+
+		// check status code
+		expectedStatusCode := http.StatusOK
+		if response.StatusCode != expectedStatusCode {
+			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, response.StatusCode)
+		}
+
+		// unmarshal body
+		body := readBody(t, response)
+		jsonBody := struct {
+			Data api.SignTransactionResponse `json:"data"`
+		}{}
+		err = json.Unmarshal([]byte(body), &jsonBody)
+		if err != nil {
+			t.Errorf("unexpected response body format: %s", err)
+		}
+
+		// check signature is verifiable
+		keyPair := device.KeyPair.(*crypto.ECCKeyPair)
+		digest, err := crypto.ComputeHashDigest([]byte(jsonBody.Data.SignedData))
+		if err != nil {
+			t.Fatal(err)
+		}
+		decodedSignature, err := base64.StdEncoding.DecodeString(jsonBody.Data.Signature)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := ecdsa.VerifyASN1(keyPair.Public, digest, decodedSignature)
+		if !result {
+			t.Errorf("verification of signed data and signature failed. err: %s, signed data: %s, signature: %s", err, jsonBody.Data.SignedData, jsonBody.Data.Signature)
+		}
+
+		// check signed_data is correct format
+		expectedSignedData := fmt.Sprintf("0_%s_%s", dataToSign, base64EncodedId)
+		if jsonBody.Data.SignedData != expectedSignedData {
+			t.Errorf("expected signed data: %s, got: %s", expectedSignedData, jsonBody.Data.SignedData)
+		}
+
+		// check persisted data
+		device, ok, err := repository.Find(uuid.MustParse(id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("device not found")
+		}
+		if device.SignatureCounter != 1 {
+			t.Errorf("device signature counter should be incremented to 1, got: %d", device.SignatureCounter)
+		}
+		if device.Base64EncodedLastSignature != jsonBody.Data.Signature {
+			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.Base64EncodedLastSignature)
+		}
+	})
+
+	t.Run("successfully signs data (algorithm: ECC, counter > 0)", func(t *testing.T) {
+		id := "64ff796e-fcde-499a-a03d-82dd1f89e8e5"
+		dataToSign := "some-data"
+
+		// create a device that has been used once
+		device, err := domain.BuildSignatureDevice(uuid.MustParse(id), crypto.ECCGenerator{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		device.SignatureCounter = 1
+		device.Base64EncodedLastSignature = "last-signature-base-64-encoded"
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		err = repository.Create(device)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signatureService := api.NewSignatureService(repository)
+		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
+		defer testServer.Close()
+
+		response := sendJsonRequest(
+			t,
+			http.MethodPost,
+			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
+			api.SignTransactionRequest{Data: dataToSign},
+		)
+
+		// check status code
+		expectedStatusCode := http.StatusOK
+		if response.StatusCode != expectedStatusCode {
+			t.Errorf("expected status code: %d, got: %d", expectedStatusCode, response.StatusCode)
+		}
+
+		// unmarshal body
+		body := readBody(t, response)
+		jsonBody := struct {
+			Data api.SignTransactionResponse `json:"data"`
+		}{}
+		err = json.Unmarshal([]byte(body), &jsonBody)
+		if err != nil {
+			t.Errorf("unexpected response body format: %s", err)
+		}
+
+		// check signature is verifiable
+		digest, err := crypto.ComputeHashDigest([]byte(jsonBody.Data.SignedData))
+		if err != nil {
+			t.Fatal(err)
+		}
+		decodedSignature, err := base64.StdEncoding.DecodeString(jsonBody.Data.Signature)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyPair := device.KeyPair.(*crypto.ECCKeyPair)
+		result := ecdsa.VerifyASN1(keyPair.Public, digest, decodedSignature)
+		if !result {
 			t.Errorf("verification of signed data and signature failed. err: %s, signed data: %s, signature: %s", err, jsonBody.Data.SignedData, jsonBody.Data.Signature)
 		}
 

--- a/signing-service-challenge-go/api/server.go
+++ b/signing-service-challenge-go/api/server.go
@@ -39,6 +39,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux := chi.NewMux()
 	mux.Get("/api/v0/health", http.HandlerFunc(s.Health))
 	mux.Post("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
+	mux.Post("/api/v0/signature_devices/{deviceID}/signatures", http.HandlerFunc(s.signatureService.SignTransaction))
 	return mux
 }
 

--- a/signing-service-challenge-go/crypto/ecdsa.go
+++ b/signing-service-challenge-go/crypto/ecdsa.go
@@ -14,7 +14,7 @@ type ECCKeyPair struct {
 }
 
 func (keyPair ECCKeyPair) Sign(dataToBeSigned []byte) ([]byte, error) {
-	digest, err := computeHashDigest(dataToBeSigned)
+	digest, err := ComputeHashDigest(dataToBeSigned)
 	if err != nil {
 		return nil, err
 	}

--- a/signing-service-challenge-go/crypto/ecdsa_test.go
+++ b/signing-service-challenge-go/crypto/ecdsa_test.go
@@ -18,7 +18,7 @@ func TestECCKeyPair_Sign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	digest, err := computeHashDigest([]byte(dataToBeSigned))
+	digest, err := ComputeHashDigest([]byte(dataToBeSigned))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signing-service-challenge-go/crypto/rsa.go
+++ b/signing-service-challenge-go/crypto/rsa.go
@@ -14,7 +14,7 @@ type RSAKeyPair struct {
 }
 
 func (keyPair RSAKeyPair) Sign(dataToBeSigned []byte) (signature []byte, err error) {
-	digest, err := computeHashDigest(dataToBeSigned)
+	digest, err := ComputeHashDigest(dataToBeSigned)
 	if err != nil {
 		return nil, err
 	}

--- a/signing-service-challenge-go/crypto/rsa_test.go
+++ b/signing-service-challenge-go/crypto/rsa_test.go
@@ -18,7 +18,7 @@ func TestRSASigner_Sign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	digest, err := computeHashDigest([]byte(dataToBeSigned))
+	digest, err := ComputeHashDigest([]byte(dataToBeSigned))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signing-service-challenge-go/crypto/signer.go
+++ b/signing-service-challenge-go/crypto/signer.go
@@ -11,7 +11,7 @@ import (
 // makes collisions less likely.
 const HashFunction = stdcrypto.SHA384
 
-func computeHashDigest(b []byte) ([]byte, error) {
+func ComputeHashDigest(b []byte) ([]byte, error) {
 	hash := HashFunction.New()
 	_, err := hash.Write(b)
 	if err != nil {

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -47,7 +47,7 @@ func SecureDataToBeSigned(device SignatureDevice, data string) string {
 		encodedID := base64.StdEncoding.EncodeToString([]byte(device.ID.String()))
 		components = append(components, encodedID)
 	} else {
-		encodedLastSignature := base64.StdEncoding.EncodeToString([]byte(device.Base64EncodedLastSignature))
+		encodedLastSignature := device.Base64EncodedLastSignature
 		components = append(components, encodedLastSignature)
 	}
 

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -83,11 +83,10 @@ func TestSignTransaction(t *testing.T) {
 
 func TestSecureDataToBeSigned(t *testing.T) {
 	t.Run("concatenates data with counter and last signature when counter > 0", func(t *testing.T) {
-		lastSignature := "last-signature"
 		base64EncodedLastSignature := "bGFzdC1zaWduYXR1cmU="
 
 		device := domain.SignatureDevice{
-			Base64EncodedLastSignature: lastSignature,
+			Base64EncodedLastSignature: base64EncodedLastSignature,
 			SignatureCounter:           1,
 		}
 		data := "some transaction data"


### PR DESCRIPTION
## Objective

Implement `POST /api/v0/signature_devices/:deviceID/signatures` 

## What was changed

### `api` package

- implemented the endpoint at `SignatureService.SignTransaction`
- added the route to `Server`


### `crypto` package

- renamed `computeHashDigest` to `ComputeHashDigest` for convenience in tests

### `domain` package

- fixed a bug in `SecureDataToBeSigned`, where the last signature was being base64 encoded twice

## QA

`POST /api/v0/signature_devices/:deviceID/signatures`

- [x] request to sign with a device id that does not exist returns 404

```
$ curl -iXPOST localhost:
8080/api/v0/signature_devices/1b6bfcac-441e-4498-b1e8-5df44dd3d086/signatures -d '{"data": "some-data-2
"}'
HTTP/1.1 404 Not Found
Date: Sun, 28 Jan 2024 18:10:22 GMT
Content-Length: 41
Content-Type: text/plain; charset=utf-8

{"errors":["signature device not found"]}
```

- [x] signing data for the first time with an RSA device succeeds

```
$ curl -iXPOST localhost:
8080/api/v0/signature_devices/1b6bfcac-441e-4498-b1e8-5df44dd3d087/signatures -d '{"data": "some-data"}
'
HTTP/1.1 200 OK
Date: Sun, 28 Jan 2024 18:08:14 GMT
Content-Length: 210
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "signature": "SzsTbfybRowFj2C9Fr4rVNbtKxvvV+aEoEoi3neeaSEq7ZEOxEBFk7MNhq7oQV/Cy4wB2nhWtGl7GT7Xk2rGDg==",
    "signed_data": "0_some-data_MWI2YmZjYWMtNDQxZS00NDk4LWIxZTgtNWRmNDRkZDNkMDg3"
  }
}
```

- [x] signing data for the second time with an RSA device succeeds

```
$ curl -iXPOST localhost:
8080/api/v0/signature_devices/1b6bfcac-441e-4498-b1e8-5df44dd3d087/signatures -d '{"data": "some-data-2
"}'
HTTP/1.1 200 OK
Date: Sun, 28 Jan 2024 18:08:45 GMT
Content-Length: 252
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "signature": "WmoqpVX9Iazv+YPDEntAPLTREb8T0EuWXV8Jca+sz3OARcVtoFTpttfpGONipDMICT2sYbSvQLVdtG9sUakKZA==",
    "signed_data": "1_some-data-2_SzsTbfybRowFj2C9Fr4rVNbtKxvvV+aEoEoi3neeaSEq7ZEOxEBFk7MNhq7oQV/Cy4wB2nhWtGl7GT7Xk2rGDg=="
  }
}
```

- [x] signing data for the first time with an ECC device succeeds

```
$ curl -iXPOST localhost:
8080/api/v0/signature_devices/1f2d27a0-33e9-4dec-8b78-66e020220a83/signatures -d '{"data": "some-data-3
"}'
HTTP/1.1 200 OK
Date: Sun, 28 Jan 2024 18:11:47 GMT
Content-Length: 264
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "signature": "MGYCMQCpZAexjdu8jv+PSs8+QfdWwXTl5584hlVpfSS6+XFlTBDpFgzWMMsvsfds+KxDj9ECMQDc2/kQtB44MKlrzDZw/8NJHXtja7FQ9+OPsWTUAkmMJqAlFXeWOjTrox03HLHtNDo=",
    "signed_data": "0_some-data-3_MWYyZDI3YTAtMzNlOS00ZGVjLThiNzgtNjZlMDIwMjIwYTgz"
  }
}                                                                                  
```

- [x] signing data for the second time with an ECC device succeeds

```
$ curl -iXPOST localhost:
8080/api/v0/signature_devices/1f2d27a0-33e9-4dec-8b78-66e020220a83/signatures -d '{"data": "some-data-4
"}'
HTTP/1.1 200 OK
Date: Sun, 28 Jan 2024 18:12:14 GMT
Content-Length: 356
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "signature": "MGYCMQDIJBE04LuGD9X/L+6Qohtwi1nAUNtkAMETDkYAv3v4TgPq+sQX9Mjg6qXvRssxj6MCMQD1FOD6EG1Ju4wI/oFr5ha8oOA8bWQLoncWqQLIBzX8XDOuVuKxVoaG8eYEWL3FH5o=",
    "signed_data": "1_some-data-4_MGYCMQCpZAexjdu8jv+PSs8+QfdWwXTl5584hlVpfSS6+XFlTBDpFgzWMMsvsfds+KxDj9ECMQDc2/kQtB44MKlrzDZw/8NJHXtja7FQ9+OPsWTUAkmMJqAlFXeWOjTrox03HLHtNDo="
  }
}
```