### PR TITLE
start a server in api tests so that routing will also be tested

### DIFF
--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -1,10 +1,7 @@
 package api_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -242,43 +239,4 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 			t.Errorf("key pair generation failed: %s", err)
 		}
 	})
-}
-
-func sendJsonRequest(
-	t *testing.T,
-	httpMethod string,
-	url string,
-	serializableData ...any,
-) *http.Response {
-	var bodyReader io.Reader
-	if len(serializableData) > 0 {
-		jsonBytes, err := json.Marshal(serializableData[0])
-		if err != nil {
-			t.Fatal(fmt.Sprintf("json.Marshal failed: err"))
-		}
-		bodyReader = bytes.NewReader(jsonBytes)
-	}
-
-	request, err := http.NewRequest(httpMethod, url, bodyReader)
-	if err != nil {
-		panic(fmt.Sprintf("json.Marshal failed: err"))
-	}
-	request.Header.Set("Content-Type", "application/json")
-
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return response
-}
-
-func readBody(t *testing.T, response *http.Response) string {
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer response.Body.Close()
-
-	return string(body)
 }

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -248,18 +248,18 @@ func sendJsonRequest(
 	t *testing.T,
 	httpMethod string,
 	url string,
-	serializableData any,
+	serializableData ...any,
 ) *http.Response {
-	jsonBytes, err := json.Marshal(serializableData)
-	if err != nil {
-		panic(fmt.Sprintf("json.Marshal failed: err"))
+	var bodyReader io.Reader
+	if len(serializableData) > 0 {
+		jsonBytes, err := json.Marshal(serializableData[0])
+		if err != nil {
+			t.Fatal(fmt.Sprintf("json.Marshal failed: err"))
+		}
+		bodyReader = bytes.NewReader(jsonBytes)
 	}
 
-	request, err := http.NewRequest(
-		httpMethod,
-		url,
-		bytes.NewReader(jsonBytes),
-	)
+	request, err := http.NewRequest(httpMethod, url, bodyReader)
 	if err != nil {
 		panic(fmt.Sprintf("json.Marshal failed: err"))
 	}

--- a/signing-service-challenge-go/api/health_test.go
+++ b/signing-service-challenge-go/api/health_test.go
@@ -6,21 +6,28 @@ import (
 	"testing"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/api"
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/persistence"
 )
 
 func TestHealth(t *testing.T) {
-	request := httptest.NewRequest(http.MethodGet, "/api/v0/health", nil)
-	responseRecorder := httptest.NewRecorder()
+	repository := persistence.NewInMemorySignatureDeviceRepository()
+	signatureService := api.NewSignatureService(repository)
+	server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
+	defer server.Close()
 
-	server := api.NewServer("", api.SignatureService{})
-	server.Health(responseRecorder, request)
+	response := sendJsonRequest(
+		t,
+		http.MethodGet,
+		server.URL+"/api/v0/health",
+		"", // TODO: make this optional?
+	)
 
 	expectedStatusCode := http.StatusOK
-	if responseRecorder.Code != expectedStatusCode {
-		t.Errorf("expected status code: %d, got: %d", expectedStatusCode, responseRecorder.Code)
+	if response.StatusCode != expectedStatusCode {
+		t.Errorf("expected status code: %d, got: %d", expectedStatusCode, response.StatusCode)
 	}
 
-	body := responseRecorder.Body.String()
+	body := readBody(t, response)
 	expectedBody := `{
   "data": {
     "status": "pass",

--- a/signing-service-challenge-go/api/health_test.go
+++ b/signing-service-challenge-go/api/health_test.go
@@ -19,7 +19,6 @@ func TestHealth(t *testing.T) {
 		t,
 		http.MethodGet,
 		server.URL+"/api/v0/health",
-		"", // TODO: make this optional?
 	)
 
 	expectedStatusCode := http.StatusOK

--- a/signing-service-challenge-go/api/helpers_test.go
+++ b/signing-service-challenge-go/api/helpers_test.go
@@ -41,6 +41,8 @@ func sendJsonRequest(
 }
 
 func readBody(t *testing.T, response *http.Response) string {
+	t.Helper()
+
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatal(err)

--- a/signing-service-challenge-go/api/helpers_test.go
+++ b/signing-service-challenge-go/api/helpers_test.go
@@ -1,0 +1,51 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func sendJsonRequest(
+	t *testing.T,
+	httpMethod string,
+	url string,
+	serializableData ...any,
+) *http.Response {
+	t.Helper()
+
+	var bodyReader io.Reader
+	if len(serializableData) > 0 {
+		jsonBytes, err := json.Marshal(serializableData[0])
+		if err != nil {
+			t.Fatal(fmt.Sprintf("json.Marshal failed: err"))
+		}
+		bodyReader = bytes.NewReader(jsonBytes)
+	}
+
+	request, err := http.NewRequest(httpMethod, url, bodyReader)
+	if err != nil {
+		panic(fmt.Sprintf("json.Marshal failed: err"))
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return response
+}
+
+func readBody(t *testing.T, response *http.Response) string {
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	return string(body)
+}

--- a/signing-service-challenge-go/api/helpers_test.go
+++ b/signing-service-challenge-go/api/helpers_test.go
@@ -28,7 +28,7 @@ func sendJsonRequest(
 
 	request, err := http.NewRequest(httpMethod, url, bodyReader)
 	if err != nil {
-		panic(fmt.Sprintf("json.Marshal failed: err"))
+		t.Fatal(fmt.Sprintf("json.Marshal failed: err"))
 	}
 	request.Header.Set("Content-Type", "application/json")
 

--- a/signing-service-challenge-go/api/server.go
+++ b/signing-service-challenge-go/api/server.go
@@ -34,14 +34,16 @@ func NewServer(
 	}
 }
 
-// Run registers all HandlerFuncs for the existing HTTP routes and starts the Server.
-func (s *Server) Run() error {
+// Register all HandlerFuncs for routes
+func (s *Server) HTTPHandler() http.Handler {
 	mux := chi.NewMux()
-
 	mux.Get("/api/v0/health", http.HandlerFunc(s.Health))
 	mux.Post("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
+	return mux
+}
 
-	return http.ListenAndServe(s.listenAddress, mux)
+func (s *Server) Run() error {
+	return http.ListenAndServe(s.listenAddress, s.HTTPHandler())
 }
 
 // WriteInternalError writes a default internal error message as an HTTP response.


### PR DESCRIPTION
## Objectives

Use an actual http server in `api` package tests. 
This makes the tests closer to the actual production environment, and also makes the tests covers routing.
URL parameters accessed through `chi.URLParam` will also become accessible in tests.

## Changes made

- expose the http handler in `Server.HTTPHandler()`
- use the above http handler in api tests, and send actual http requests
- define some helpers in `api/helpers_test.go`

## QA
- [x] `GET /api/v0/health` succeeds
- [x] `POST /api/v0/signature_devices` succeeds