### PR TITLE
use snake_case in API response keys

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -21,7 +21,7 @@ func NewSignatureService(repository domain.SignatureDeviceRepository) SignatureS
 }
 
 type CreateSignatureDeviceResponse struct {
-	ID string `json:"signatureDeviceId"`
+	ID string `json:"signature_device_id"`
 }
 
 type CreateSignatureDeviceRequest struct {

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -157,7 +157,7 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		body := readBody(t, response)
 		expectedBody := fmt.Sprintf(`{
   "data": {
-    "signatureDeviceId": "%s"
+    "signature_device_id": "%s"
   }
 }`, id)
 		diff := cmp.Diff(body, expectedBody)
@@ -216,7 +216,7 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		body := readBody(t, response)
 		expectedBody := fmt.Sprintf(`{
   "data": {
-    "signatureDeviceId": "%s"
+    "signature_device_id": "%s"
   }
 }`, id)
 		diff := cmp.Diff(body, expectedBody)


### PR DESCRIPTION
## Objective

There are both `snake_case` and `camelCase` keys in the json responses, so unify into `snake_case`

## Changes made
- rename `signatureDeviceId` to `signature_device_id` in the response of `POST /api/v0/signature_devices`

## QA
- [x] `signature_device_id` is used in response of `POST /api/v0/signature_devices`