### PR TITLE
rename `POST /api/v0/signature_devices/:id/signatures body` request `data` -> `data_to_be_signed`

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -89,7 +89,7 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 }
 
 type SignTransactionRequest struct {
-	Data string `json:"data"`
+	DataToBeSigned string `json:"data_to_be_signed"`
 }
 
 type SignTransactionResponse struct {
@@ -131,7 +131,7 @@ func (s *SignatureService) SignTransaction(response http.ResponseWriter, request
 	encodedSignature, signedData, err := domain.SignTransaction(
 		device,
 		s.signatureDeviceRepository,
-		requestBody.Data,
+		requestBody.DataToBeSigned,
 	)
 	if err != nil {
 		WriteInternalError(response)

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -258,7 +258,7 @@ func TestSignTransaction(t *testing.T) {
 			t,
 			http.MethodPost,
 			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
-			api.SignTransactionRequest{Data: "some-data"},
+			api.SignTransactionRequest{DataToBeSigned: "some-data"},
 		)
 
 		// check status code
@@ -299,7 +299,7 @@ func TestSignTransaction(t *testing.T) {
 			t,
 			http.MethodPost,
 			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
-			api.SignTransactionRequest{Data: dataToSign},
+			api.SignTransactionRequest{DataToBeSigned: dataToSign},
 		)
 
 		// check status code
@@ -380,7 +380,7 @@ func TestSignTransaction(t *testing.T) {
 			t,
 			http.MethodPost,
 			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
-			api.SignTransactionRequest{Data: dataToSign},
+			api.SignTransactionRequest{DataToBeSigned: dataToSign},
 		)
 
 		// check status code
@@ -459,7 +459,7 @@ func TestSignTransaction(t *testing.T) {
 			t,
 			http.MethodPost,
 			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
-			api.SignTransactionRequest{Data: dataToSign},
+			api.SignTransactionRequest{DataToBeSigned: dataToSign},
 		)
 
 		// check status code
@@ -540,7 +540,7 @@ func TestSignTransaction(t *testing.T) {
 			t,
 			http.MethodPost,
 			fmt.Sprintf("%s/api/v0/signature_devices/%s/signatures", testServer.URL, id),
-			api.SignTransactionRequest{Data: dataToSign},
+			api.SignTransactionRequest{DataToBeSigned: dataToSign},
 		)
 
 		// check status code


### PR DESCRIPTION
# Objective

rename an ambiguous request body key

# Changes made

rename `data` in `SignTransactionRequest` to `data_to_be_signed`

# QA

- [x] `POST /api/v0/signature_devices/:id/signatures` succeeds with `data_to_be_signed` in request body
