### PR TITLE
improve `InMemorySignatureDeviceRepository` to be concurrent access safe

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -81,6 +81,9 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		return
 	}
 
+	mutex := s.signatureDeviceRepository.Mutex()
+	mutex.Lock()
+	defer mutex.Unlock()
 	err = s.signatureDeviceRepository.Create(device)
 	if err != nil {
 		// In a real application, this error would be logged and sent to an error notification service

--- a/signing-service-challenge-go/api/health.go
+++ b/signing-service-challenge-go/api/health.go
@@ -1,9 +1,6 @@
 package api
 
-import (
-	"net/http"
-	"time"
-)
+import "net/http"
 
 type HealthResponse struct {
 	Status  string `json:"status"`
@@ -12,8 +9,6 @@ type HealthResponse struct {
 
 // Health evaluates the health of the service and writes a standardized response.
 func (s *Server) Health(response http.ResponseWriter, request *http.Request) {
-	time.Sleep(time.Second * 7)
-
 	health := HealthResponse{
 		Status:  "pass",
 		Version: "v0",

--- a/signing-service-challenge-go/api/health.go
+++ b/signing-service-challenge-go/api/health.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 type HealthResponse struct {
 	Status  string `json:"status"`
@@ -9,6 +12,8 @@ type HealthResponse struct {
 
 // Health evaluates the health of the service and writes a standardized response.
 func (s *Server) Health(response http.ResponseWriter, request *http.Request) {
+	time.Sleep(time.Second * 7)
+
 	health := HealthResponse{
 		Status:  "pass",
 		Version: "v0",

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -53,8 +54,14 @@ func BuildSignatureDevice(id uuid.UUID, generator KeyPairGenerator, label ...str
 }
 
 type SignatureDeviceRepository interface {
+	// WARNING: all operations must obtain a read lock or a write lock from `Mutex()`
 	Create(device SignatureDevice) error
 	Update(device SignatureDevice) error
 	Find(id uuid.UUID) (SignatureDevice, bool, error)
 	List() ([]SignatureDevice, error)
+
+	// Only necessary while data is persisted in memory.
+	// If data is migrated to external databases, some other method
+	// (e.g. transactions and locking reads for MySQL) should be used.
+	Mutex() *sync.RWMutex
 }

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -17,14 +17,19 @@ func SignTransaction(
 	signedData string,
 	err error,
 ) {
+	// 1. Read `lastSignature` and `signatureCounter` from `device`
+	//    (these values cannot change until update is complete)
+	//    If data was persisted in MySQL, for example, a locking read would be used
 	securedDataToBeSigned := SecureDataToBeSigned(device, dataToBeSigned)
 
+	// 2. Use the data read in 1. to create the signature
 	signature, err := device.Sign(securedDataToBeSigned)
 	if err != nil {
 		return "", "", errors.New(fmt.Sprintf("failed to sign transaction: %s", err))
 	}
 	encodedSignature := base64.StdEncoding.EncodeToString(signature)
 
+	// 3. Update the device, and release the lock
 	device.Base64EncodedLastSignature = encodedSignature
 	device.SignatureCounter++
 	err = deviceRepository.Update(device)

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -14,11 +14,25 @@ import (
 )
 
 func TestSignTransaction(t *testing.T) {
+	t.Run("returns deviceFound: false when device with id does not exist", func(t *testing.T) {
+		dataToBeSigned := "some-transaction-data"
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		deviceID := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
+
+		deviceFound, _, _, err := domain.SignTransaction(deviceID, repository, dataToBeSigned)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deviceFound {
+			t.Fatal("device should not be found, as it does not exist")
+		}
+	})
+
 	t.Run("successfully signs when device is being used for the first time", func(t *testing.T) {
 		dataToBeSigned := "some-transaction-data"
 		repository := persistence.NewInMemorySignatureDeviceRepository()
-		deviceId := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
-		device, err := domain.BuildSignatureDevice(deviceId, crypto.RSAGenerator{})
+		deviceID := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
+		device, err := domain.BuildSignatureDevice(deviceID, crypto.RSAGenerator{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,9 +41,12 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		encodedSignature, signedData, err := domain.SignTransaction(device, repository, dataToBeSigned)
+		deviceFound, encodedSignature, signedData, err := domain.SignTransaction(deviceID, repository, dataToBeSigned)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if !deviceFound {
+			t.Fatal("device not found")
 		}
 
 		base64EncodedDeviceId := "MTIxZmU0MDItNzYyYS00MTFhLThlZWItOWU2YzNjYTE2ODg2"
@@ -65,7 +82,7 @@ func TestSignTransaction(t *testing.T) {
 
 		// check updates to signature device
 		// refetch the device from the repository to reflect updates
-		device, ok, err := repository.Find(deviceId)
+		device, ok, err := repository.Find(deviceID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 
 type InMemorySignatureDeviceRepository struct {
 	devices map[uuid.UUID]domain.SignatureDevice
+	lock    *sync.RWMutex
 }
 
 func (repository InMemorySignatureDeviceRepository) Create(device domain.SignatureDevice) error {

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -11,7 +11,7 @@ import (
 
 type InMemorySignatureDeviceRepository struct {
 	devices map[uuid.UUID]domain.SignatureDevice
-	lock    *sync.RWMutex
+	mutex   *sync.RWMutex
 }
 
 func (repository InMemorySignatureDeviceRepository) Create(device domain.SignatureDevice) error {
@@ -56,6 +56,10 @@ func (repository InMemorySignatureDeviceRepository) List() ([]domain.SignatureDe
 	}
 
 	return allDevices, nil
+}
+
+func (repository InMemorySignatureDeviceRepository) Mutex() *sync.RWMutex {
+	return repository.mutex
 }
 
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -65,5 +65,6 @@ func (repository InMemorySignatureDeviceRepository) Mutex() *sync.RWMutex {
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {
 	return InMemorySignatureDeviceRepository{
 		devices: map[uuid.UUID]domain.SignatureDevice{},
+		mutex:   &sync.RWMutex{},
 	}
 }


### PR DESCRIPTION

## Requirements 

> - The system will be used by many concurrent clients accessing the same resources.
> - The `signature_counter` has to be strictly monotonically increasing and ideally without any gaps.

https://github.com/fiskaly/coding-challenges/blob/2a887d6239c595cf2d575d9ea0f15adda73cd2c0/signing-service-challenge-go/README.md?plain=1#L77-L78

When executing `domain.SignTransaction`, the following needs to happen **atomically**

1. Read `lastSignature` and `signatureCounter` from `device` (these values cannot be changed by other concurrent requests until 3. is complete)
    - If data was persisted in MySQL, for example, a locking read would be used
2. Use the data read in 1. to compose the string to be signed: `<signature_counter>_<data_to_be_signed>_<last_signature_base64_encoded>`
3. Update the signature device: increment `signatureCounter` by 1, and change value of `lastSignature` to the signature generated in 2.

Another thing to consider, concurrent access to maps in Go is not considered safe.
ref: https://go.dev/blog/maps , https://go.dev/doc/faq#atomic_maps 

## Approaches considered

### Approach 1. Hold a mutex in `InMemorySignatureDeviceRepository`, and lock / unlock the mutex inside each method

- lock the mutex at the start of each method, and unlock at the end of each method (using defer)

```
request A  ① ----- ② ------ ③ 
request B        ① ------ ② ------ ③ 

(time) --------->
```

If a situation like the above occurs, where requestB reads the values before requestA finishes updating, then request B would update the signature device with the wrong data at step 3.
Therefore, this approach will not meet the requirements.

### Approach 2. Hold a mutex in `InMemorySignatureDeviceRepository`, and lock / unlock the mutex outside each method

- This would work, but the responsibility of preventing concurrent access to the internal map would be handed to logic outside of the repository, and this could cause accidents in the future.
- Also, this would leak implementation details of `InMemorySignatureDeviceRepository` out into the interface of `SignatureDeviceRepository` (which cannot always be prevented but should nevertheless be avoided when possible)
  - This could possibly be avoided by holding the mutex outside of the repository?

### Approach 3. Use goroutines and channels

- Something like https://gobyexample.com/stateful-goroutines
  - However, there cannot be one channel for reads and one channel for writes, as the logic of `domain.SignTransaction` requires a read AND a write to be executed together, atomically.
- This could also work (depending on the implementation), but all operations would need to go through the channel, and this would make refactoring to use an external database even more difficult than Approach 2.
