### PR TITLE
return same data in `POST /signature_devices` as `GET /signature_devices/:id`

### DIFF
--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -154,35 +154,27 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		}
 
 		// check body
-		body := readBody(t, response)
-		expectedBody := fmt.Sprintf(`{
-  "data": {
-    "signature_device_id": "%s"
-  }
-}`, id)
-		diff := cmp.Diff(body, expectedBody)
-		if diff != "" {
-			t.Errorf("unexpected diff: %s", diff)
-		}
-
-		// check persisted data
-		device, found, err := repository.Find(id)
+		createdDevice, ok, err := repository.Find(id)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
-		if !found {
-			t.Error("expected device with id to be found")
-		}
-		if device.ID != id {
-			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
-		}
-		if device.Label != "" {
-			t.Errorf("label not persisted correctly. expected blank string, got: %s", device.Label)
-		}
-		_, ok := device.KeyPair.(*crypto.RSAKeyPair)
 		if !ok {
-			t.Errorf("key pair generation failed: %s", err)
+			t.Error("created device not found")
 		}
+		publicKey, err := createdDevice.KeyPair.EncodedPublicKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		compareResponseBodyData(
+			t,
+			response,
+			api.CreateSignatureDeviceResponse{
+				ID:        id.String(),
+				Algorithm: algorithmName,
+				Label:     "",
+				PublicKey: publicKey,
+			},
+		)
 	})
 
 	t.Run("creates a SignatureDevice with a label successfully", func(t *testing.T) {
@@ -213,35 +205,27 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		}
 
 		// check body
-		body := readBody(t, response)
-		expectedBody := fmt.Sprintf(`{
-  "data": {
-    "signature_device_id": "%s"
-  }
-}`, id)
-		diff := cmp.Diff(body, expectedBody)
-		if diff != "" {
-			t.Errorf("unexpected diff: %s", diff)
-		}
-
-		// check persisted data
-		device, found, err := repository.Find(id)
+		createdDevice, ok, err := repository.Find(id)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
-		if !found {
-			t.Error("expected device with id to be found")
-		}
-		if device.ID != id {
-			t.Errorf("id not persisted correctly. expected: %s, got: %s", id, device.ID)
-		}
-		if device.Label != label {
-			t.Errorf("label not persisted correctly. expected: %s, got: %s", label, device.Label)
-		}
-		_, ok := device.KeyPair.(*crypto.RSAKeyPair)
 		if !ok {
-			t.Errorf("key pair generation failed: %s", err)
+			t.Error("created device not found")
 		}
+		publicKey, err := createdDevice.KeyPair.EncodedPublicKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		compareResponseBodyData(
+			t,
+			response,
+			api.CreateSignatureDeviceResponse{
+				ID:        id.String(),
+				Algorithm: algorithmName,
+				Label:     label,
+				PublicKey: publicKey,
+			},
+		)
 	})
 }
 


### PR DESCRIPTION
## Objective

Improve the response data in `POST /signature_devices` by returning the same data as `GET /signature_devices/:id`

## Changes made

### `api` package

- unified the `Response` structs of `POST /signature_devices` and `GET /signature_devices/:id`

## QA
- [x] response of  `POST /signature_devices` has changed

```
$ curl -iXPOST localhost:8080/api/v0/sign
ature_devices -d '{"id": "1b6bfcac-441e-4498-b1e8-5df44dd3d087", "algorithm": "RSA"}'
HTTP/1.1 201 Created
~/c/f/signing-service-challenge-go (yusukemorita/improve-response-body-create-signature-device) $ curl -iXPOST localhost:8080/api/v0/sign
ature_devices -d '{"id": "1f2d27a0-33e9-4dec-8b78-66e020220a83", "algorithm": "ECC", "label": "my ecc key"}'
HTTP/1.1 201 Created
Date: Mon, 29 Jan 2024 15:28:26 GMT
Content-Length: 361
Content-Type: text/plain; charset=utf-8

{
  "data": {
    "id": "1f2d27a0-33e9-4dec-8b78-66e020220a83",
    "label": "my ecc key",
    "public_key": "-----BEGIN PUBLIC_KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAER8FSAkTvS4xRfjhEjtlAxJcO8173Xx3g\nuILbURT9kEaEUIvJdVWMTNvy2mJRSQWDSnHaZwYhMQHKIikRlJzI4e8AozUW1hUK\nJG/AzzJCiTGq4AbuiSzzCYZY2F3IqTmZ\n-----END PUBLIC_KEY-----\n",
    "algorithm": "ECC"
  }
}
```