### PR TITLE
implement `GET /api/v0/signature_devices`

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
@@ -202,4 +203,42 @@ func (s *SignatureService) FindSignatureDevice(response http.ResponseWriter, req
 			Algorithm: device.KeyPair.AlgorithmName(),
 		},
 	)
+}
+
+type ListSignatureDevicesResponse = []ApiSignatureDevice
+
+func (s *SignatureService) ListSignatureDevice(response http.ResponseWriter, request *http.Request) {
+	devices, err := s.signatureDeviceRepository.List()
+	if err != nil {
+		WriteInternalError(response)
+		return
+	}
+
+	// sort devices by ID
+	// This is just so that the order remains stable, what the order is determined by
+	// is irrelevant
+	slices.SortStableFunc(devices, func(a, b domain.SignatureDevice) int {
+		if a.ID.String() > b.ID.String() {
+			return 1
+		} else {
+			return -1
+		}
+	})
+
+	responseBody := ListSignatureDevicesResponse{}
+	for _, device := range devices {
+		publicKey, err := device.KeyPair.EncodedPublicKey()
+		if err != nil {
+			WriteInternalError(response)
+			return
+		}
+		responseBody = append(responseBody, ApiSignatureDevice{
+			ID:        device.ID.String(),
+			Label:     device.Label,
+			Algorithm: device.KeyPair.AlgorithmName(),
+			PublicKey: publicKey,
+		})
+	}
+
+	WriteAPIResponse(response, http.StatusOK, responseBody)
 }

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"slices"
+	"sort"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
@@ -217,12 +217,10 @@ func (s *SignatureService) ListSignatureDevice(response http.ResponseWriter, req
 	// sort devices by ID
 	// This is just so that the order remains stable, what the order is determined by
 	// is irrelevant
-	slices.SortStableFunc(devices, func(a, b domain.SignatureDevice) int {
-		if a.ID.String() > b.ID.String() {
-			return 1
-		} else {
-			return -1
-		}
+	sort.SliceStable(devices, func(a, b int) bool {
+		deviceA := devices[a]
+		deviceB := devices[b]
+		return deviceA.ID.String() < deviceB.ID.String()
 	})
 
 	responseBody := ListSignatureDevicesResponse{}

--- a/signing-service-challenge-go/api/server.go
+++ b/signing-service-challenge-go/api/server.go
@@ -41,6 +41,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux.Post("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.CreateSignatureDevice))
 	mux.Post("/api/v0/signature_devices/{deviceID}/signatures", http.HandlerFunc(s.signatureService.SignTransaction))
 	mux.Get("/api/v0/signature_devices/{deviceID}", http.HandlerFunc(s.signatureService.FindSignatureDevice))
+	mux.Get("/api/v0/signature_devices", http.HandlerFunc(s.signatureService.ListSignatureDevice))
 	return mux
 }
 

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -56,4 +56,5 @@ type SignatureDeviceRepository interface {
 	Create(device SignatureDevice) error
 	Update(device SignatureDevice) error
 	Find(id uuid.UUID) (SignatureDevice, bool, error)
+	List() ([]SignatureDevice, error)
 }

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -41,6 +41,17 @@ func (repository InMemorySignatureDeviceRepository) Find(id uuid.UUID) (domain.S
 	return device, true, nil
 }
 
+// order is not guaranteed
+func (repository InMemorySignatureDeviceRepository) List() ([]domain.SignatureDevice, error) {
+	allDevices := []domain.SignatureDevice{}
+
+	for _, device := range repository.devices {
+		allDevices = append(allDevices, device)
+	}
+
+	return allDevices, nil
+}
+
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {
 	return InMemorySignatureDeviceRepository{
 		devices: map[uuid.UUID]domain.SignatureDevice{},

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -41,7 +41,11 @@ func (repository InMemorySignatureDeviceRepository) Find(id uuid.UUID) (domain.S
 	return device, true, nil
 }
 
-// order is not guaranteed
+// Order is not guaranteed
+// ref: https://go.dev/blog/maps
+// > When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed
+// > to be the same from one iteration to the next. If you require a stable iteration order you must maintain
+// > a separate data structure that specifies that order.
 func (repository InMemorySignatureDeviceRepository) List() ([]domain.SignatureDevice, error) {
 	allDevices := []domain.SignatureDevice{}
 

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
@@ -174,4 +175,45 @@ func TestFind(t *testing.T) {
 			t.Error("expected found: false")
 		}
 	})
+}
+
+func TestList(t *testing.T) {
+	repository := NewInMemorySignatureDeviceRepository()
+
+	// create rsa device
+	rsaDevice, err := domain.BuildSignatureDevice(
+		uuid.New(),
+		crypto.RSAGenerator{},
+		"my rsa key",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository.devices[rsaDevice.ID] = rsaDevice
+
+	// create ecc device
+	eccDevice, err := domain.BuildSignatureDevice(
+		uuid.New(),
+		crypto.ECCGenerator{},
+		"my ecc key",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository.devices[eccDevice.ID] = eccDevice
+
+	got, err := repository.List()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 devices, got %d", len(got))
+	}
+
+	if !slices.Contains(got, rsaDevice) {
+		t.Error("expected got to contain rsa device")
+	}
+	if !slices.Contains(got, eccDevice) {
+		t.Error("expected got to contain ecc device")
+	}
 }

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -1,7 +1,6 @@
 package persistence
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
@@ -210,10 +209,10 @@ func TestList(t *testing.T) {
 		t.Errorf("expected 2 devices, got %d", len(got))
 	}
 
-	if !slices.Contains(got, rsaDevice) {
+	if got[0] != rsaDevice && got[1] != rsaDevice {
 		t.Error("expected got to contain rsa device")
 	}
-	if !slices.Contains(got, eccDevice) {
+	if got[0] != eccDevice && got[1] != eccDevice {
 		t.Error("expected got to contain ecc device")
 	}
 }


### PR DESCRIPTION
## Objective 

Implement an endpoint that retrieves all signature devices

## Changes made

### `api` package

- implement `SignatureService.ListSignatureDevice()` and add route

### `domain` package

- add `List` method to `SignatureDeviceRepository` interface

### `persistence` package

- implement `List` method in `InMemorySignatureDeviceRepository`

## QA

- [x] `GET /api/v0/signature_devices` returns all devices, in a stable order

example response

```
 $ curl -iXGET localhost:8080/api/v0/signature_devices
HTTP/1.1 200 OK
Date: Mon, 29 Jan 2024 17:03:24 GMT
Content-Length: 680
Content-Type: text/plain; charset=utf-8

{
  "data": [
    {
      "id": "1b6bfcac-441e-4498-b1e8-5df44dd3d087",
      "label": "",
      "public_key": "-----BEGIN RSA_PUBLIC_KEY-----\nMEgCQQCimYqViRYPTmpj8ctC2T0rBe+I5z6oW3RIbRT1KMT6EbXiBCdmRCGSk8WP\ncYVwQFLt2XGp2+hA/Fy47XXLcSjfAgMBAAE=\n-----END RSA_PUBLIC_KEY-----\n",
      "algorithm": "RSA"
    },
    {
      "id": "1f2d27a0-33e9-4dec-8b78-66e020220a83",
      "label": "my ecc key",
      "public_key": "-----BEGIN PUBLIC_KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEwH7pRARrYh20OiRt6J/8vxygRcik3E+0\n2uUx2nU1Meftegcjs24mhQ0uSlHlqtua+IhgjMZe+KL4aJEkfy7z0gGFWgjgjHE/\nJT5Jvf4AG7LDF+i1Zjw0UtKbqggpZFDF\n-----END PUBLIC_KEY-----\n",
      "algorithm": "ECC"
    }
  ]
}
```