### PR TITLE
improve access to persisted data to be concurrency safe

### DIFF
--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -81,6 +81,9 @@ func (s *SignatureService) CreateSignatureDevice(response http.ResponseWriter, r
 		return
 	}
 
+	mutex := s.signatureDeviceRepository.Mutex()
+	mutex.Lock()
+	defer mutex.Unlock()
 	err = s.signatureDeviceRepository.Create(device)
 	if err != nil {
 		// In a real application, this error would be logged and sent to an error notification service

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -23,8 +23,11 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		id := "invalid-uuid"
 		algorithmName := crypto.RSAGenerator{}.AlgorithmName()
 
-		repository := persistence.NewInMemorySignatureDeviceRepository()
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(
+				persistence.NewInMemorySignatureDeviceRepository(),
+			),
+		)
 		server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer server.Close()
 
@@ -67,7 +70,9 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 			KeyPair: keyPair,
 		})
 
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer server.Close()
 
@@ -99,8 +104,11 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		id := uuid.New()
 		algorithmName := "ABC"
 
-		repository := persistence.NewInMemorySignatureDeviceRepository()
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(
+				persistence.NewInMemorySignatureDeviceRepository(),
+			),
+		)
 		server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer server.Close()
 
@@ -133,7 +141,9 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		algorithmName := crypto.RSAGenerator{}.AlgorithmName()
 
 		repository := persistence.NewInMemorySignatureDeviceRepository()
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer server.Close()
 
@@ -183,7 +193,9 @@ func TestCreateSignatureDeviceResponse(t *testing.T) {
 		label := "my RSA key"
 
 		repository := persistence.NewInMemorySignatureDeviceRepository()
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer server.Close()
 
@@ -233,8 +245,11 @@ func TestSignTransaction(t *testing.T) {
 	t.Run("returns not found when device with id does not exist", func(t *testing.T) {
 		id := uuid.NewString()
 
-		repository := persistence.NewInMemorySignatureDeviceRepository()
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(
+				persistence.NewInMemorySignatureDeviceRepository(),
+			),
+		)
 		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -275,7 +290,9 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -356,7 +373,9 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -435,7 +454,9 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -516,7 +537,9 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		testServer := httptest.NewServer(api.NewServer(":8888", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -586,7 +609,9 @@ func TestFindSignatureDevice(t *testing.T) {
 		id := uuid.NewString()
 
 		repository := persistence.NewInMemorySignatureDeviceRepository()
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		testServer := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -628,7 +653,9 @@ func TestFindSignatureDevice(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		signatureService := api.NewSignatureService(repository)
+		signatureService := api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+		)
 		testServer := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 		defer testServer.Close()
 
@@ -692,7 +719,9 @@ func TestListSignatureDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signatureService := api.NewSignatureService(repository)
+	signatureService := api.NewSignatureService(
+		persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+	)
 	testServer := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 	defer testServer.Close()
 

--- a/signing-service-challenge-go/api/health.go
+++ b/signing-service-challenge-go/api/health.go
@@ -1,9 +1,6 @@
 package api
 
-import (
-	"net/http"
-	"time"
-)
+import "net/http"
 
 type HealthResponse struct {
 	Status  string `json:"status"`
@@ -12,8 +9,6 @@ type HealthResponse struct {
 
 // Health evaluates the health of the service and writes a standardized response.
 func (s *Server) Health(response http.ResponseWriter, request *http.Request) {
-	time.Sleep(time.Second * 7)
-
 	health := HealthResponse{
 		Status:  "pass",
 		Version: "v0",

--- a/signing-service-challenge-go/api/health.go
+++ b/signing-service-challenge-go/api/health.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 type HealthResponse struct {
 	Status  string `json:"status"`
@@ -9,6 +12,8 @@ type HealthResponse struct {
 
 // Health evaluates the health of the service and writes a standardized response.
 func (s *Server) Health(response http.ResponseWriter, request *http.Request) {
+	time.Sleep(time.Second * 7)
+
 	health := HealthResponse{
 		Status:  "pass",
 		Version: "v0",

--- a/signing-service-challenge-go/api/health_test.go
+++ b/signing-service-challenge-go/api/health_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	repository := persistence.NewInMemorySignatureDeviceRepository()
-	signatureService := api.NewSignatureService(repository)
+	signatureService := api.NewSignatureService(
+		persistence.NewInMemorySignatureDeviceRepositoryProvider(
+			persistence.NewInMemorySignatureDeviceRepository(),
+		),
+	)
 	server := httptest.NewServer(api.NewServer("", signatureService).HTTPHandler())
 	defer server.Close()
 

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -55,9 +55,9 @@ func BuildSignatureDevice(id uuid.UUID, generator KeyPairGenerator, label ...str
 // WARNING:
 // All operations must be executed inside WriteTx() or ReadTx(),
 // as Go maps are not safe for concurrent use.
-// For this reason, do not hold the `SignatureDeviceRepository` directly
+// For this reason, do not expose the `SignatureDeviceRepository` directly
 // to the `api` package.
-// Instead, hold the `SignatureDeviceRepositoryProvider`, which ensures
+// Instead, expose the `SignatureDeviceRepositoryProvider`, which ensures
 // that every operation will be executed inside a transaction.
 type SignatureDeviceRepository interface {
 	Create(device SignatureDevice) error

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -52,12 +52,21 @@ func BuildSignatureDevice(id uuid.UUID, generator KeyPairGenerator, label ...str
 	return device, nil
 }
 
+// WARNING:
+// All operations must be executed inside WriteTx() or ReadTx(),
+// as Go maps are not safe for concurrent use.
+// For this reason, do not hold the `SignatureDeviceRepository` directly
+// to the `api` package.
+// Instead, hold the `SignatureDeviceRepositoryProvider`, which ensures
+// that every operation will be executed inside a transaction.
 type SignatureDeviceRepository interface {
-	// WARNING: all operations must be executed inside Tx(func() error)
 	Create(device SignatureDevice) error
 	Update(device SignatureDevice) error
 	Find(id uuid.UUID) (SignatureDevice, bool, error)
 	List() ([]SignatureDevice, error)
+}
 
-	Tx(do func() error) error
+type SignatureDeviceRepositoryProvider interface {
+	WriteTx(func(SignatureDeviceRepository) error) error
+	ReadTx(func(SignatureDeviceRepository) error) error
 }

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -53,8 +54,14 @@ func BuildSignatureDevice(id uuid.UUID, generator KeyPairGenerator, label ...str
 }
 
 type SignatureDeviceRepository interface {
+	// WARNING: all operations must obtain a read lock or a write lock from `Mutex()`
 	Create(device SignatureDevice) error
 	Update(device SignatureDevice) error
 	Find(id uuid.UUID) (SignatureDevice, bool, error)
 	List() ([]SignatureDevice, error)
+
+	// Only necessary while data is persisted in memory.
+	// If data is migrated to external databases, some other method
+	// (e.g. transactions and locking reads for MySQL) should be used.
+	Mutex() *sync.RWMutex
 }

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/google/uuid"
 )
@@ -54,14 +53,11 @@ func BuildSignatureDevice(id uuid.UUID, generator KeyPairGenerator, label ...str
 }
 
 type SignatureDeviceRepository interface {
-	// WARNING: all operations must obtain a read lock or a write lock from `Mutex()`
+	// WARNING: all operations must be executed inside Tx(func() error)
 	Create(device SignatureDevice) error
 	Update(device SignatureDevice) error
 	Find(id uuid.UUID) (SignatureDevice, bool, error)
 	List() ([]SignatureDevice, error)
 
-	// Only necessary while data is persisted in memory.
-	// If data is migrated to external databases, some other method
-	// (e.g. transactions and locking reads for MySQL) should be used.
-	Mutex() *sync.RWMutex
+	Tx(do func() error) error
 }

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -17,14 +17,19 @@ func SignTransaction(
 	signedData string,
 	err error,
 ) {
+	// 1. Read `lastSignature` and `signatureCounter` from `device`
+	//    (these values cannot change until update is complete)
+	//    If data was persisted in MySQL, for example, a locking read would be used
 	securedDataToBeSigned := SecureDataToBeSigned(device, dataToBeSigned)
 
+	// 2. Use the data read in 1. to create the signature
 	signature, err := device.Sign(securedDataToBeSigned)
 	if err != nil {
 		return "", "", errors.New(fmt.Sprintf("failed to sign transaction: %s", err))
 	}
 	encodedSignature := base64.StdEncoding.EncodeToString(signature)
 
+	// 3. Update the device, and release the lock
 	device.Base64EncodedLastSignature = encodedSignature
 	device.SignatureCounter++
 	err = deviceRepository.Update(device)

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -12,7 +12,7 @@ import (
 
 func SignTransaction(
 	deviceID uuid.UUID,
-	deviceRepository SignatureDeviceRepository,
+	repositoryProvider SignatureDeviceRepositoryProvider,
 	dataToBeSigned string,
 ) (
 	deviceFound bool,
@@ -20,8 +20,8 @@ func SignTransaction(
 	signedData string,
 	err error,
 ) {
-	txErr := deviceRepository.Tx(func() error {
-		device, ok, err := deviceRepository.Find(deviceID)
+	txErr := repositoryProvider.WriteTx(func(repository SignatureDeviceRepository) error {
+		device, ok, err := repository.Find(deviceID)
 		if err != nil {
 			return err
 		}
@@ -46,7 +46,7 @@ func SignTransaction(
 		// 3. Update the device, and release the lock
 		device.Base64EncodedLastSignature = encodedSignature
 		device.SignatureCounter++
-		err = deviceRepository.Update(device)
+		err = repository.Update(device)
 		if err != nil {
 			return errors.New(fmt.Sprintf("failed to update signature device: %s", err))
 		}

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -31,19 +31,13 @@ func SignTransaction(
 		}
 		deviceFound = true
 
-		// 1. Read `lastSignature` and `signatureCounter` from `device`
-		//    (these values cannot change until update is complete)
-		//    If data was persisted in MySQL, for example, a locking read would be used
 		signedData = SecureDataToBeSigned(device, dataToBeSigned)
-
-		// 2. Use the data read in 1. to create the signature
 		signature, err := device.Sign(signedData)
 		if err != nil {
 			return errors.New(fmt.Sprintf("failed to sign transaction: %s", err))
 		}
 		encodedSignature = base64.StdEncoding.EncodeToString(signature)
 
-		// 3. Update the device, and release the lock
 		device.Base64EncodedLastSignature = encodedSignature
 		device.SignatureCounter++
 		err = repository.Update(device)

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -16,39 +16,49 @@ func SignTransaction(
 	dataToBeSigned string,
 ) (
 	deviceFound bool,
-	base64EncodedSignature string,
+	encodedSignature string,
 	signedData string,
 	err error,
 ) {
-	device, ok, err := deviceRepository.Find(deviceID)
-	if err != nil {
-		return false, "", "", err
-	}
-	if !ok {
-		return false, "", "", nil
+	txErr := deviceRepository.Tx(func() error {
+		device, ok, err := deviceRepository.Find(deviceID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			deviceFound = false
+			return nil
+		}
+		deviceFound = true
+
+		// 1. Read `lastSignature` and `signatureCounter` from `device`
+		//    (these values cannot change until update is complete)
+		//    If data was persisted in MySQL, for example, a locking read would be used
+		signedData = SecureDataToBeSigned(device, dataToBeSigned)
+
+		// 2. Use the data read in 1. to create the signature
+		signature, err := device.Sign(signedData)
+		if err != nil {
+			return errors.New(fmt.Sprintf("failed to sign transaction: %s", err))
+		}
+		encodedSignature = base64.StdEncoding.EncodeToString(signature)
+
+		// 3. Update the device, and release the lock
+		device.Base64EncodedLastSignature = encodedSignature
+		device.SignatureCounter++
+		err = deviceRepository.Update(device)
+		if err != nil {
+			return errors.New(fmt.Sprintf("failed to update signature device: %s", err))
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		return false, "", "", txErr
 	}
 
-	// 1. Read `lastSignature` and `signatureCounter` from `device`
-	//    (these values cannot change until update is complete)
-	//    If data was persisted in MySQL, for example, a locking read would be used
-	securedDataToBeSigned := SecureDataToBeSigned(device, dataToBeSigned)
-
-	// 2. Use the data read in 1. to create the signature
-	signature, err := device.Sign(securedDataToBeSigned)
-	if err != nil {
-		return false, "", "", errors.New(fmt.Sprintf("failed to sign transaction: %s", err))
-	}
-	encodedSignature := base64.StdEncoding.EncodeToString(signature)
-
-	// 3. Update the device, and release the lock
-	device.Base64EncodedLastSignature = encodedSignature
-	device.SignatureCounter++
-	err = deviceRepository.Update(device)
-	if err != nil {
-		return false, "", "", errors.New(fmt.Sprintf("failed to update signature device: %s", err))
-	}
-
-	return true, encodedSignature, securedDataToBeSigned, nil
+	return
 }
 
 func SecureDataToBeSigned(device SignatureDevice, data string) string {

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -141,9 +141,3 @@ func TestSecureDataToBeSigned(t *testing.T) {
 		}
 	})
 }
-
-// RSA
-// 1b6bfcac-441e-4498-b1e8-5df44dd3d087
-
-// ECC
-// 1f2d27a0-33e9-4dec-8b78-66e020220a83

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -141,3 +141,9 @@ func TestSecureDataToBeSigned(t *testing.T) {
 		}
 	})
 }
+
+// RSA
+// 1b6bfcac-441e-4498-b1e8-5df44dd3d087
+
+// ECC
+// 1f2d27a0-33e9-4dec-8b78-66e020220a83

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -16,10 +16,12 @@ import (
 func TestSignTransaction(t *testing.T) {
 	t.Run("returns deviceFound: false when device with id does not exist", func(t *testing.T) {
 		dataToBeSigned := "some-transaction-data"
-		repository := persistence.NewInMemorySignatureDeviceRepository()
+		provider := persistence.NewInMemorySignatureDeviceRepositoryProvider(
+			persistence.NewInMemorySignatureDeviceRepository(),
+		)
 		deviceID := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
 
-		deviceFound, _, _, err := domain.SignTransaction(deviceID, repository, dataToBeSigned)
+		deviceFound, _, _, err := domain.SignTransaction(deviceID, provider, dataToBeSigned)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -41,7 +43,11 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		deviceFound, encodedSignature, signedData, err := domain.SignTransaction(deviceID, repository, dataToBeSigned)
+		deviceFound, encodedSignature, signedData, err := domain.SignTransaction(
+			deviceID,
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(repository),
+			dataToBeSigned,
+		)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -14,11 +14,25 @@ import (
 )
 
 func TestSignTransaction(t *testing.T) {
+	t.Run("returns deviceFound: false when device with id does not exist", func(t *testing.T) {
+		dataToBeSigned := "some-transaction-data"
+		repository := persistence.NewInMemorySignatureDeviceRepository()
+		deviceID := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
+
+		deviceFound, _, _, err := domain.SignTransaction(deviceID, repository, dataToBeSigned)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if deviceFound {
+			t.Fatal("device should not be found, as it does not exist")
+		}
+	})
+
 	t.Run("successfully signs when device is being used for the first time", func(t *testing.T) {
 		dataToBeSigned := "some-transaction-data"
 		repository := persistence.NewInMemorySignatureDeviceRepository()
-		deviceId := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
-		device, err := domain.BuildSignatureDevice(deviceId, crypto.RSAGenerator{})
+		deviceID := uuid.MustParse("121fe402-762a-411a-8eeb-9e6c3ca16886")
+		device, err := domain.BuildSignatureDevice(deviceID, crypto.RSAGenerator{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,9 +41,12 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		encodedSignature, signedData, err := domain.SignTransaction(device, repository, dataToBeSigned)
+		deviceFound, encodedSignature, signedData, err := domain.SignTransaction(deviceID, repository, dataToBeSigned)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if !deviceFound {
+			t.Fatal("device not found")
 		}
 
 		base64EncodedDeviceId := "MTIxZmU0MDItNzYyYS00MTFhLThlZWItOWU2YzNjYTE2ODg2"
@@ -65,7 +82,7 @@ func TestSignTransaction(t *testing.T) {
 
 		// check updates to signature device
 		// refetch the device from the repository to reflect updates
-		device, ok, err := repository.Find(deviceId)
+		device, ok, err := repository.Find(deviceID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/signing-service-challenge-go/main.go
+++ b/signing-service-challenge-go/main.go
@@ -15,7 +15,11 @@ const (
 func main() {
 	server := api.NewServer(
 		ListenAddress,
-		api.NewSignatureService(persistence.NewInMemorySignatureDeviceRepository()),
+		api.NewSignatureService(
+			persistence.NewInMemorySignatureDeviceRepositoryProvider(
+				persistence.NewInMemorySignatureDeviceRepository(),
+			),
+		),
 	)
 
 	if err := server.Run(); err != nil {

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 
 type InMemorySignatureDeviceRepository struct {
 	devices map[uuid.UUID]domain.SignatureDevice
+	lock    *sync.RWMutex
 }
 
 func (repository InMemorySignatureDeviceRepository) Create(device domain.SignatureDevice) error {

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -11,7 +11,7 @@ import (
 
 type InMemorySignatureDeviceRepository struct {
 	devices map[uuid.UUID]domain.SignatureDevice
-	lock    *sync.RWMutex
+	mutex   *sync.RWMutex
 }
 
 func (repository InMemorySignatureDeviceRepository) Create(device domain.SignatureDevice) error {
@@ -56,6 +56,10 @@ func (repository InMemorySignatureDeviceRepository) List() ([]domain.SignatureDe
 	}
 
 	return allDevices, nil
+}
+
+func (repository InMemorySignatureDeviceRepository) Mutex() *sync.RWMutex {
+	return repository.mutex
 }
 
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -65,5 +65,6 @@ func (repository InMemorySignatureDeviceRepository) Mutex() *sync.RWMutex {
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {
 	return InMemorySignatureDeviceRepository{
 		devices: map[uuid.UUID]domain.SignatureDevice{},
+		mutex:   &sync.RWMutex{},
 	}
 }

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -58,8 +58,10 @@ func (repository InMemorySignatureDeviceRepository) List() ([]domain.SignatureDe
 	return allDevices, nil
 }
 
-func (repository InMemorySignatureDeviceRepository) Mutex() *sync.RWMutex {
-	return repository.mutex
+func (repository InMemorySignatureDeviceRepository) Tx(do func() error) error {
+	repository.mutex.Lock()
+	defer repository.mutex.Unlock()
+	return do()
 }
 
 func NewInMemorySignatureDeviceRepository() InMemorySignatureDeviceRepository {


### PR DESCRIPTION
## Objective

Make access to the data in `SignatureDeviceRepository` safe to access concurrently

## Changes made

Approach 3. of "Approaches Considered" below was implemented.

### `persistence` package

- implement `InMemorySignatureDeviceRepositoryProvider`, uses a `sync.RWMutex` to control concurrent calls to  `InMemorySignatureDeviceRepository` methods

### `api` package

- hold `SignatureDeviceRepositoryProvider` instead of `SignatureDeviceRepository` in `SignatureService`, and access all repository methods through the provider

### `domain` package

- add `SignatureDeviceRepositoryProvider` interface
- refactor `SignTransaction` to include all queries to the database necessary, as they need to be wrapped in the same transaction

## QA

requests to the following endpoints succeed

- [x] `GET /api/v0/signature_devices`
- [x] `GET /api/v0/signature_devices/:id`
- [x] `POST /api/v0/signature_devices`
- [x] `POST /api/v0/signature_devices/:id/signatures`

## Other

### Requirements

> - The system will be used by many concurrent clients accessing the same resources.
> - The `signature_counter` has to be strictly monotonically increasing and ideally without any gaps.

https://github.com/fiskaly/coding-challenges/blob/2a887d6239c595cf2d575d9ea0f15adda73cd2c0/signing-service-challenge-go/README.md?plain=1#L77-L78

When executing `domain.SignTransaction`, the following needs to happen **atomically**

1. Read `lastSignature` and `signatureCounter` from `device` (these values cannot be changed by other concurrent requests until 3. is complete)
    - If data was persisted in MySQL, for example, a locking read would be used
2. Use the data read in 1. to compose the string to be signed: `<signature_counter>_<data_to_be_signed>_<last_signature_base64_encoded>`
3. Update the signature device: increment `signatureCounter` by 1, and change value of `lastSignature` to the signature generated in 2.

Another thing to consider, concurrent access to maps in Go is not considered safe.
ref: https://go.dev/blog/maps , https://go.dev/doc/faq#atomic_maps 

### Approaches considered

#### Approach 1. Hold a mutex in `InMemorySignatureDeviceRepository`, and lock / unlock the mutex inside each method

- lock the mutex at the start of each method, and unlock at the end of each method (using defer)

```
request A  ① ----- ② ------ ③ 
request B        ① ------ ② ------ ③ 

(time) --------->
```

If a situation like the above occurs, where requestB reads the values before requestA finishes updating, then request B would update the signature device with the wrong data at step 3.
Therefore, this approach will not meet the requirements.

#### Approach 2. Hold a mutex in `InMemorySignatureDeviceRepository`, and lock / unlock the mutex outside each method

- This would work, but the responsibility of preventing concurrent access to the internal map would be handed to logic outside of the repository, and this could cause accidents in the future.
- Also, this would leak implementation details of `InMemorySignatureDeviceRepository` out into the interface of `SignatureDeviceRepository` (which cannot always be prevented but should nevertheless be avoided when possible)
  - This could possibly be avoided by holding the mutex outside of the repository?

#### ✅ Approach 3. Hold a mutex **outside** `InMemorySignatureDeviceRepository`, and lock / unlock the mutex outside each method

```go
func (p Provider) Tx(do func(repo Repository) error) error {
  p.mutex.Lock()
  defer p.mutex.Unlock()
  return do(p.repository)
}
```

- Implement a `Provider`, which manages transactions and provides the repository
- If the repository is only accessed through the provider, we can guarantee that all operations are done inside of transactions, i.e. inside a `mutex.Lock()` / `mutex.Unlock`. Less likelihood of forgetting to use the mutex, compared to approach 2
- Also, the `sync.RWmutex` would not have to be exposed as part of the API of the repository
- As a drawback (not compared to approach 2, but in general), **every operation** must be **explicitly** in a transaction. 
  - This is different from when implementing with a RDB. For example, in MySQL (InnoDB) single queries will implicitly be in a transaction, however there is no need to declare this in the code and it is automatic. This means some implementation details are leaking outside of the `persistence` package.
  - However it is not always possible to keep implementation details perfectly abstracted, so 

#### Approach 4. Use goroutines and channels

- Something like https://gobyexample.com/stateful-goroutines
  - However, there cannot be one channel for reads and one channel for writes, as the logic of `domain.SignTransaction` requires a read AND a write to be executed together, atomically.
- This could also work (depending on the implementation), but all operations would need to go through the channel, and this would make refactoring to use an external database even more difficult than Approach 2.

