### PR TITLE
strictly increment `SignatureDevice.SignatureCounter`

### DIFF
--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -351,8 +351,8 @@ func TestSignTransaction(t *testing.T) {
 		if device.SignatureCounter != 1 {
 			t.Errorf("device signature counter should be incremented to 1, got: %d", device.SignatureCounter)
 		}
-		if device.Base64EncodedLastSignature != jsonBody.Data.Signature {
-			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.Base64EncodedLastSignature)
+		if device.LastSignature != jsonBody.Data.Signature {
+			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.LastSignature)
 		}
 	})
 
@@ -366,7 +366,7 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 		device.SignatureCounter = 1
-		device.Base64EncodedLastSignature = "last-signature-base-64-encoded"
+		device.LastSignature = "last-signature-base-64-encoded"
 		repository := persistence.NewInMemorySignatureDeviceRepository()
 		err = repository.Create(device)
 		if err != nil {
@@ -418,7 +418,7 @@ func TestSignTransaction(t *testing.T) {
 		}
 
 		// check signed_data is correct format
-		expectedSignedData := fmt.Sprintf("1_%s_%s", dataToSign, device.Base64EncodedLastSignature)
+		expectedSignedData := fmt.Sprintf("1_%s_%s", dataToSign, device.LastSignature)
 		if jsonBody.Data.SignedData != expectedSignedData {
 			t.Errorf("expected signed data: %s, got: %s", expectedSignedData, jsonBody.Data.SignedData)
 		}
@@ -434,8 +434,8 @@ func TestSignTransaction(t *testing.T) {
 		if device.SignatureCounter != 2 {
 			t.Errorf("device signature counter should be incremented to 2, got: %d", device.SignatureCounter)
 		}
-		if device.Base64EncodedLastSignature != jsonBody.Data.Signature {
-			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.Base64EncodedLastSignature)
+		if device.LastSignature != jsonBody.Data.Signature {
+			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.LastSignature)
 		}
 	})
 
@@ -515,8 +515,8 @@ func TestSignTransaction(t *testing.T) {
 		if device.SignatureCounter != 1 {
 			t.Errorf("device signature counter should be incremented to 1, got: %d", device.SignatureCounter)
 		}
-		if device.Base64EncodedLastSignature != jsonBody.Data.Signature {
-			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.Base64EncodedLastSignature)
+		if device.LastSignature != jsonBody.Data.Signature {
+			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.LastSignature)
 		}
 	})
 
@@ -530,7 +530,7 @@ func TestSignTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 		device.SignatureCounter = 1
-		device.Base64EncodedLastSignature = "last-signature-base-64-encoded"
+		device.LastSignature = "last-signature-base-64-encoded"
 		repository := persistence.NewInMemorySignatureDeviceRepository()
 		err = repository.Create(device)
 		if err != nil {
@@ -582,7 +582,7 @@ func TestSignTransaction(t *testing.T) {
 		}
 
 		// check signed_data is correct format
-		expectedSignedData := fmt.Sprintf("1_%s_%s", dataToSign, device.Base64EncodedLastSignature)
+		expectedSignedData := fmt.Sprintf("1_%s_%s", dataToSign, device.LastSignature)
 		if jsonBody.Data.SignedData != expectedSignedData {
 			t.Errorf("expected signed data: %s, got: %s", expectedSignedData, jsonBody.Data.SignedData)
 		}
@@ -598,8 +598,8 @@ func TestSignTransaction(t *testing.T) {
 		if device.SignatureCounter != 2 {
 			t.Errorf("device signature counter should be incremented to 2, got: %d", device.SignatureCounter)
 		}
-		if device.Base64EncodedLastSignature != jsonBody.Data.Signature {
-			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.Base64EncodedLastSignature)
+		if device.LastSignature != jsonBody.Data.Signature {
+			t.Errorf("device last signature should be updated to %s, got: %s", jsonBody.Data.Signature, device.LastSignature)
 		}
 	})
 }

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -23,8 +23,8 @@ type SignatureDevice struct {
 	KeyPair KeyPair
 	// (optional) user provided string to be displayed in the UI
 	Label string
-	// track the last signature created with this device
-	Base64EncodedLastSignature string
+	// track the base64 encoded last signature created with this device
+	LastSignature string
 	// track how many signatures have been created with this device
 	SignatureCounter uint
 }

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -61,7 +61,8 @@ func BuildSignatureDevice(id uuid.UUID, generator KeyPairGenerator, label ...str
 // that every operation will be executed inside a transaction.
 type SignatureDeviceRepository interface {
 	Create(device SignatureDevice) error
-	Update(device SignatureDevice) error
+	// Increment the signatureCounter, and update the lastSignature
+	MarkSignatureCreated(deviceID uuid.UUID, newSignature string) error
 	Find(id uuid.UUID) (SignatureDevice, bool, error)
 	List() ([]SignatureDevice, error)
 }

--- a/signing-service-challenge-go/domain/device_test.go
+++ b/signing-service-challenge-go/domain/device_test.go
@@ -51,8 +51,8 @@ func TestBuildSignatureDevice(t *testing.T) {
 			t.Errorf("expected initial signature counter value to be 0, got: %d", device.SignatureCounter)
 		}
 
-		if device.Base64EncodedLastSignature != "" {
-			t.Errorf("expected initial last signature value to be blank, got: %s", device.Base64EncodedLastSignature)
+		if device.LastSignature != "" {
+			t.Errorf("expected initial last signature value to be blank, got: %s", device.LastSignature)
 		}
 
 		if device.Label != "" {

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -65,7 +65,7 @@ func SecureDataToBeSigned(device SignatureDevice, data string) string {
 		encodedID := base64.StdEncoding.EncodeToString([]byte(device.ID.String()))
 		components = append(components, encodedID)
 	} else {
-		encodedLastSignature := device.Base64EncodedLastSignature
+		encodedLastSignature := device.LastSignature
 		components = append(components, encodedLastSignature)
 	}
 

--- a/signing-service-challenge-go/domain/sign.go
+++ b/signing-service-challenge-go/domain/sign.go
@@ -38,9 +38,7 @@ func SignTransaction(
 		}
 		encodedSignature = base64.StdEncoding.EncodeToString(signature)
 
-		device.Base64EncodedLastSignature = encodedSignature
-		device.SignatureCounter++
-		err = repository.Update(device)
+		err = repository.MarkSignatureCreated(device.ID, encodedSignature)
 		if err != nil {
 			return errors.New(fmt.Sprintf("failed to update signature device: %s", err))
 		}

--- a/signing-service-challenge-go/domain/sign_test.go
+++ b/signing-service-challenge-go/domain/sign_test.go
@@ -98,8 +98,8 @@ func TestSignTransaction(t *testing.T) {
 		if device.SignatureCounter != 1 {
 			t.Errorf("expected signature counter to be incremented to 1, got %d", device.SignatureCounter)
 		}
-		if device.Base64EncodedLastSignature != encodedSignature {
-			t.Errorf("expected last signature to be updated to: %s, got %s", encodedSignature, device.Base64EncodedLastSignature)
+		if device.LastSignature != encodedSignature {
+			t.Errorf("expected last signature to be updated to: %s, got %s", encodedSignature, device.LastSignature)
 		}
 	})
 }
@@ -109,8 +109,8 @@ func TestSecureDataToBeSigned(t *testing.T) {
 		base64EncodedLastSignature := "bGFzdC1zaWduYXR1cmU="
 
 		device := domain.SignatureDevice{
-			Base64EncodedLastSignature: base64EncodedLastSignature,
-			SignatureCounter:           1,
+			LastSignature:    base64EncodedLastSignature,
+			SignatureCounter: 1,
 		}
 		data := "some transaction data"
 
@@ -127,9 +127,9 @@ func TestSecureDataToBeSigned(t *testing.T) {
 		base64EncodedID := "ZWQ0MDU5N2MtNTJiNy00MGJjLTllMTUtODNlNDc0MWExMDJi"
 
 		device := domain.SignatureDevice{
-			ID:                         id,
-			Base64EncodedLastSignature: "",
-			SignatureCounter:           0,
+			ID:               id,
+			LastSignature:    "",
+			SignatureCounter: 0,
 		}
 		data := "some transaction data"
 

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -56,7 +56,7 @@ func (repository InMemorySignatureDeviceRepository) MarkSignatureCreated(deviceI
 	}
 
 	device.SignatureCounter++
-	device.Base64EncodedLastSignature = newSignature
+	device.LastSignature = newSignature
 	repository.devices[deviceID] = device
 
 	return nil

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -49,13 +49,16 @@ func (repository InMemorySignatureDeviceRepository) Create(device domain.Signatu
 	return nil
 }
 
-func (repository InMemorySignatureDeviceRepository) Update(device domain.SignatureDevice) error {
-	_, ok := repository.devices[device.ID]
+func (repository InMemorySignatureDeviceRepository) MarkSignatureCreated(deviceID uuid.UUID, newSignature string) error {
+	device, ok := repository.devices[deviceID]
 	if !ok {
 		return errors.New("cannot update signature device that does not exist")
 	}
 
-	repository.devices[device.ID] = device
+	device.SignatureCounter++
+	device.Base64EncodedLastSignature = newSignature
+	repository.devices[deviceID] = device
+
 	return nil
 }
 

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -81,8 +81,8 @@ func TestCreate(t *testing.T) {
 	})
 }
 
-func TestUpdate(t *testing.T) {
-	t.Run("updates attributes when device with id is found", func(t *testing.T) {
+func TestMarkSignatureCreated(t *testing.T) {
+	t.Run("increments counter and updates last signature when device with id is found", func(t *testing.T) {
 		id := uuid.New()
 		keyPair, err := crypto.ECCGenerator{}.Generate()
 		if err != nil {
@@ -97,15 +97,8 @@ func TestUpdate(t *testing.T) {
 		repository := NewInMemorySignatureDeviceRepository()
 		repository.devices[device.ID] = device
 
-		updatedDevice := domain.SignatureDevice{
-			ID:                         id,
-			KeyPair:                    keyPair,
-			Label:                      "my rsa key",
-			SignatureCounter:           1,
-			Base64EncodedLastSignature: "last-signature",
-		}
-
-		err = repository.Update(updatedDevice)
+		newSignature := "new-signature"
+		err = repository.MarkSignatureCreated(id, newSignature)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
@@ -114,25 +107,18 @@ func TestUpdate(t *testing.T) {
 		if !ok {
 			t.Error("device not found")
 		}
-		if got.SignatureCounter != updatedDevice.SignatureCounter || got.Base64EncodedLastSignature != updatedDevice.Base64EncodedLastSignature {
-			t.Error("device not updated correctly")
+		if got.SignatureCounter != 1 {
+			t.Errorf("expected counter to be incremented to 1, got %d", got.SignatureCounter)
+		}
+		if got.Base64EncodedLastSignature != newSignature {
+			t.Errorf("expected last signature to be updated to '%s', got '%s'", newSignature, got.Base64EncodedLastSignature)
 		}
 	})
 
 	t.Run("returns error when device with id is not found", func(t *testing.T) {
 		id := uuid.New()
-		keyPair, err := crypto.ECCGenerator{}.Generate()
-		if err != nil {
-			t.Fatal(err)
-		}
-		device := domain.SignatureDevice{
-			ID:      id,
-			KeyPair: keyPair,
-			Label:   "my rsa key",
-		}
-
 		repository := NewInMemorySignatureDeviceRepository()
-		err = repository.Update(device)
+		err := repository.MarkSignatureCreated(id, "some-signature")
 		if err == nil {
 			t.Error("expected error when updating non-existent device")
 		}

--- a/signing-service-challenge-go/persistence/inmemory_test.go
+++ b/signing-service-challenge-go/persistence/inmemory_test.go
@@ -110,8 +110,8 @@ func TestMarkSignatureCreated(t *testing.T) {
 		if got.SignatureCounter != 1 {
 			t.Errorf("expected counter to be incremented to 1, got %d", got.SignatureCounter)
 		}
-		if got.Base64EncodedLastSignature != newSignature {
-			t.Errorf("expected last signature to be updated to '%s', got '%s'", newSignature, got.Base64EncodedLastSignature)
+		if got.LastSignature != newSignature {
+			t.Errorf("expected last signature to be updated to '%s', got '%s'", newSignature, got.LastSignature)
 		}
 	})
 


### PR DESCRIPTION
## Objective

Decrease the likelihood of accidentally changing the signature counter by more than 1

## Changes made

- replace `SignatureDeviceRepository.Update` with `MarkSignatureCreated`, which increments the counter by 1 and updates the last signature
- rename `SignatureDevice.Base64EncodedLastSignature` to `LastSignature`, as it should be clear enough that it is base64 encoded through a comment + the type being a `string` and not `[]byte`
- add `signature_counter` and `last_signature` to api responses

## QA
- [x] `POST /api/v0/signature_devices/:id/signatures` increments the counter and updates last signature
- [x] `GET /api/v0/signature_devices/:id` response now contains `signature_counter` and `last_signature`
- [x] `GET /api/v0/signature_devices` response now contains `signature_counter` and `last_signature`
- [x] `POST /api/v0/signature_devices` response now contains `signature_counter` and `last_signature`
